### PR TITLE
Update examples to use `LLMRunFrame`

### DIFF
--- a/aws-strands/black-box.py
+++ b/aws-strands/black-box.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 from loguru import logger
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TTSSpeakFrame
+from pipecat.frames.frames import LLMRunFrame, TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -188,7 +188,7 @@ async def run_bot(transport: BaseTransport):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/aws-strands/explain-thinking.py
+++ b/aws-strands/explain-thinking.py
@@ -12,7 +12,7 @@ from dotenv import load_dotenv
 from loguru import logger
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TTSSpeakFrame
+from pipecat.frames.frames import LLMRunFrame, TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -230,7 +230,7 @@ async def run_bot(transport: BaseTransport):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/aws-strands/requirements.txt
+++ b/aws-strands/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn
 python-dotenv
-pipecat-ai[webrtc,daily,deepgram,cartesia]
+pipecat-ai[webrtc,daily,deepgram,cartesia,silero]>=0.0.82
+# -e ../../pipecat/[webrtc,daily,deepgram,cartesia,silero]
 pipecat-ai-small-webrtc-prebuilt
 strands-agents

--- a/chatbot-audio-recording/bot.py
+++ b/chatbot-audio-recording/bot.py
@@ -16,6 +16,7 @@ import aiohttp
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -153,7 +154,7 @@ async def main():
         async def on_first_participant_joined(transport, participant):
             await audiobuffer.start_recording()
             await transport.capture_participant_transcription(participant["id"])
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
+            await task.queue_frames([LLMRunFrame()])
 
         @transport.event_handler("on_participant_left")
         async def on_participant_left(transport, participant, reason):

--- a/chatbot-audio-recording/requirements.txt
+++ b/chatbot-audio-recording/requirements.txt
@@ -2,4 +2,4 @@ aiofiles
 python-dotenv
 fastapi[all]
 uvicorn
-pipecat-ai[daily,openai,silero,elevenlabs]
+pipecat-ai[daily,openai,silero,elevenlabs]>=0.0.82

--- a/deployment/flyio-example/bot.py
+++ b/deployment/flyio-example/bot.py
@@ -12,7 +12,7 @@ import sys
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import EndFrame
+from pipecat.frames.frames import EndFrame, LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -85,7 +85,7 @@ async def main(room_url: str, token: str):
     @transport.event_handler("on_first_participant_joined")
     async def on_first_participant_joined(transport, participant):
         await transport.capture_participant_transcription(participant["id"])
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_participant_left")
     async def on_participant_left(transport, participant, reason):

--- a/deployment/flyio-example/requirements.txt
+++ b/deployment/flyio-example/requirements.txt
@@ -1,4 +1,4 @@
-pipecat-ai[daily,openai,silero]
+pipecat-ai[daily,openai,silero]>=0.0.82
 fastapi
 uvicorn
 python-dotenv

--- a/deployment/modal-example/server/src/bot_gemini.py
+++ b/deployment/modal-example/server/src/bot_gemini.py
@@ -28,6 +28,7 @@ from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
     Frame,
+    LLMRunFrame,
     OutputImageRawFrame,
     SpriteFrame,
 )
@@ -180,7 +181,7 @@ async def run_bot(room_url: str, token: str):
     async def on_client_ready(rtvi):
         await rtvi.set_bot_ready()
         # Kick off the conversation
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_first_participant_joined")
     async def on_first_participant_joined(transport, participant):

--- a/deployment/modal-example/server/src/bot_openai.py
+++ b/deployment/modal-example/server/src/bot_openai.py
@@ -28,6 +28,7 @@ from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
     Frame,
+    LLMRunFrame,
     OutputImageRawFrame,
     SpriteFrame,
 )
@@ -208,7 +209,7 @@ async def run_bot(room_url: str, token: str):
     async def on_client_ready(rtvi):
         await rtvi.set_bot_ready()
         # Kick off the conversation
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_first_participant_joined")
     async def on_first_participant_joined(transport, participant):

--- a/deployment/modal-example/server/src/bot_vllm.py
+++ b/deployment/modal-example/server/src/bot_vllm.py
@@ -30,6 +30,7 @@ from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
     Frame,
+    LLMRunFrame,
     OutputImageRawFrame,
     SpriteFrame,
 )
@@ -221,7 +222,7 @@ async def run_bot(room_url: str, token: str):
     async def on_client_ready(rtvi):
         await rtvi.set_bot_ready()
         # Kick off the conversation
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_first_participant_joined")
     async def on_first_participant_joined(transport, participant):

--- a/exotel-chatbot/bot.py
+++ b/exotel-chatbot/bot.py
@@ -10,6 +10,7 @@ import sys
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -95,7 +96,7 @@ async def run_bot(
     async def on_client_connected(transport, client):
         # Kick off the conversation.
         messages.append({"role": "system", "content": "Please introduce yourself to the user."})
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/exotel-chatbot/requirements.txt
+++ b/exotel-chatbot/requirements.txt
@@ -1,1 +1,1 @@
-pipecat-ai[openai,silero,deepgram,cartesia,runner]>=0.0.79
+pipecat-ai[openai,silero,deepgram,cartesia,runner]>=0.0.82

--- a/fal-smart-turn/server/bot.py
+++ b/fal-smart-turn/server/bot.py
@@ -19,6 +19,7 @@ from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
     Frame,
+    LLMRunFrame,
     MetricsFrame,
     OutputImageRawFrame,
     SpriteFrame,
@@ -202,7 +203,7 @@ async def main(transport: DailyTransport):
         logger.debug("Client ready event received")
         await rtvi.set_bot_ready()
         # Kick off the conversation
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_first_participant_joined")
     async def on_first_participant_joined(transport, participant):

--- a/fal-smart-turn/server/requirements.txt
+++ b/fal-smart-turn/server/requirements.txt
@@ -1,3 +1,3 @@
 pipecatcloud
-pipecat-ai[google,daily,deepgram,cartesia,silero]
+pipecat-ai[google,daily,deepgram,cartesia,silero]>=0.0.82
 python-dotenv

--- a/freeze-test/freeze_test_bot.py
+++ b/freeze-test/freeze_test_bot.py
@@ -304,7 +304,7 @@ async def run_example(websocket_client):
         await rtvi.set_bot_ready()
         # Kick off the conversation.
         # messages.append({"role": "system", "content": "Please introduce yourself to the user."})
-        # await task.queue_frames([context_aggregator.user().get_context_frame()])
+        # await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/instant-voice/server/requirements.txt
+++ b/instant-voice/server/requirements.txt
@@ -1,4 +1,4 @@
 python-dotenv
 fastapi[all]
 uvicorn
-pipecat-ai[openai,silero,websocket,google,daily]
+pipecat-ai[openai,silero,websocket,google,daily]>=0.0.82

--- a/instant-voice/server/src/single_bot.py
+++ b/instant-voice/server/src/single_bot.py
@@ -11,6 +11,7 @@ import sys
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -101,7 +102,7 @@ async def main():
     async def on_client_ready(rtvi):
         await rtvi.set_bot_ready()
         # Kick off the conversation
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @daily_transport.event_handler("on_first_participant_joined")
     async def on_first_participant_joined(transport, participant):

--- a/moondream-chatbot/bot.py
+++ b/moondream-chatbot/bot.py
@@ -18,6 +18,7 @@ from pipecat.frames.frames import (
     BotStoppedSpeakingFrame,
     Frame,
     ImageRawFrame,
+    LLMRunFrame,
     OutputImageRawFrame,
     SpriteFrame,
     TextFrame,
@@ -201,7 +202,7 @@ async def main():
             await transport.capture_participant_transcription(participant["id"])
             await transport.capture_participant_video(participant["id"], framerate=0)
             ir.set_participant_id(participant["id"])
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
+            await task.queue_frames([LLMRunFrame()])
 
         runner = PipelineRunner()
 

--- a/moondream-chatbot/requirements.txt
+++ b/moondream-chatbot/requirements.txt
@@ -1,4 +1,4 @@
 python-dotenv
 fastapi[all]
 uvicorn
-pipecat-ai[daily,cartesia,moondream,openai,silero]
+pipecat-ai[daily,cartesia,moondream,openai,silero]>=0.0.82

--- a/news-chatbot/server/news_bot.py
+++ b/news-chatbot/server/news_bot.py
@@ -13,7 +13,7 @@ import aiohttp
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import Frame
+from pipecat.frames.frames import Frame, LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -150,7 +150,7 @@ async def main():
         async def on_client_ready(rtvi):
             await rtvi.set_bot_ready()
             # Kick off the conversation
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
+            await task.queue_frames([LLMRunFrame()])
 
         @transport.event_handler("on_first_participant_joined")
         async def on_first_participant_joined(transport, participant):

--- a/news-chatbot/server/requirements.txt
+++ b/news-chatbot/server/requirements.txt
@@ -1,4 +1,4 @@
 python-dotenv
 fastapi[all]
 uvicorn
-pipecat-ai[daily,google,deepgram,cartesia,silero,openai]
+pipecat-ai[daily,google,deepgram,cartesia,silero,openai]>=0.0.82

--- a/open-telemetry/jaeger/bot.py
+++ b/open-telemetry/jaeger/bot.py
@@ -12,7 +12,7 @@ from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExport
 from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TTSSpeakFrame
+from pipecat.frames.frames import LLMRunFrame, TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -152,7 +152,7 @@ async def run_bot(transport: BaseTransport):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/open-telemetry/jaeger/requirements.txt
+++ b/open-telemetry/jaeger/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn
 python-dotenv
-pipecat-ai[daily,webrtc,silero,cartesia,deepgram,openai,tracing]
+pipecat-ai[daily,webrtc,silero,cartesia,deepgram,openai,tracing]>=0.0.82
 pipecat-ai-small-webrtc-prebuilt
 opentelemetry-exporter-otlp-proto-grpc

--- a/open-telemetry/langfuse/bot.py
+++ b/open-telemetry/langfuse/bot.py
@@ -12,7 +12,7 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TTSSpeakFrame
+from pipecat.frames.frames import LLMRunFrame, TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -149,7 +149,7 @@ async def run_bot(transport: BaseTransport):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/open-telemetry/langfuse/requirements.txt
+++ b/open-telemetry/langfuse/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn
 python-dotenv
-pipecat-ai[daily,webrtc,silero,cartesia,deepgram,openai,tracing]
+pipecat-ai[daily,webrtc,silero,cartesia,deepgram,openai,tracing]>=0.0.82
 pipecat-ai-small-webrtc-prebuilt
 opentelemetry-exporter-otlp-proto-http

--- a/p2p-webrtc/docker/bot.py
+++ b/p2p-webrtc/docker/bot.py
@@ -8,6 +8,7 @@ import os
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -80,7 +81,7 @@ async def run_bot(webrtc_connection):
     async def on_client_connected(transport, client):
         logger.info("Pipecat Client connected")
         # Kick off the conversation.
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @pipecat_transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/p2p-webrtc/docker/requirements.txt
+++ b/p2p-webrtc/docker/requirements.txt
@@ -2,4 +2,4 @@ python-dotenv
 fastapi[all]
 uvicorn
 aiortc
-pipecat-ai[google,silero,webrtc]
+pipecat-ai[google,silero,webrtc]>=0.0.82

--- a/p2p-webrtc/video-transform/server/bot.py
+++ b/p2p-webrtc/video-transform/server/bot.py
@@ -10,7 +10,7 @@ import numpy as np
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import Frame, InputImageRawFrame, OutputImageRawFrame
+from pipecat.frames.frames import Frame, InputImageRawFrame, LLMRunFrame, OutputImageRawFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -132,7 +132,7 @@ async def run_bot(webrtc_connection):
         logger.info("Pipecat client ready.")
         await rtvi.set_bot_ready()
         # Kick off the conversation.
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @pipecat_transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):

--- a/p2p-webrtc/video-transform/server/requirements.txt
+++ b/p2p-webrtc/video-transform/server/requirements.txt
@@ -3,5 +3,5 @@ fastapi[all]
 uvicorn
 aiortc
 opencv-python
-pipecat-ai[google,silero,webrtc]
+pipecat-ai[google,silero,webrtc]>=0.0.82
 pipecat-ai-small-webrtc-prebuilt

--- a/p2p-webrtc/voice-agent/bot.py
+++ b/p2p-webrtc/voice-agent/bot.py
@@ -9,6 +9,7 @@ import sys
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -81,7 +82,7 @@ async def run_bot(webrtc_connection):
     async def on_client_connected(transport, client):
         logger.info("Pipecat Client connected")
         # Kick off the conversation.
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @pipecat_transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/p2p-webrtc/voice-agent/requirements.txt
+++ b/p2p-webrtc/voice-agent/requirements.txt
@@ -1,4 +1,4 @@
 python-dotenv
 fastapi[all]
 uvicorn
-pipecat-ai[google,silero, webrtc]
+pipecat-ai[google,silero, webrtc]>=0.0.82

--- a/phone-chatbot/daily-pstn-advanced-voicemail-detection/bot.py
+++ b/phone-chatbot/daily-pstn-advanced-voicemail-detection/bot.py
@@ -18,6 +18,7 @@ from pipecat.frames.frames import (
     EndFrame,
     EndTaskFrame,
     InputAudioRawFrame,
+    LLMRunFrame,
     StopTaskFrame,
     TranscriptionFrame,
     UserStartedSpeakingFrame,
@@ -500,10 +501,8 @@ async def run_bot(
         ]
     )
 
-    # Queue the context frame to start the conversation
-    await human_conversation_pipeline_task.queue_frames(
-        [human_conversation_context_aggregator.user().get_context_frame()]
-    )
+    # Queue an LLM run frame to start the conversation
+    await human_conversation_pipeline_task.queue_frames([LLMRunFrame()])
 
     # Run the human conversation pipeline
     try:

--- a/phone-chatbot/daily-pstn-advanced-voicemail-detection/bot.py
+++ b/phone-chatbot/daily-pstn-advanced-voicemail-detection/bot.py
@@ -26,6 +26,7 @@ from pipecat.frames.frames import (
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.processors.aggregators.llm_response import OpenAILLMContextFrame
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.services.cartesia.tts import CartesiaTTSService
 from pipecat.services.deepgram.stt import DeepgramSTTService
@@ -105,7 +106,7 @@ class UserAudioCollector(FrameProcessor):
             self._user_speaking = False
             self._context.add_audio_frames_message(audio_frames=self._audio_frames)
             await self._user_context_aggregator.push_frame(
-                self._user_context_aggregator.get_context_frame()
+                OpenAILLMContextFrame(context=self._context)
             )
         elif isinstance(frame, InputAudioRawFrame):
             if self._user_speaking:

--- a/phone-chatbot/daily-pstn-advanced-voicemail-detection/requirements.txt
+++ b/phone-chatbot/daily-pstn-advanced-voicemail-detection/requirements.txt
@@ -1,4 +1,4 @@
-pipecat-ai[daily,cartesia,google,deepgram,silero]
+pipecat-ai[daily,cartesia,google,deepgram,silero]>=0.0.82
 fastapi==0.115.6
 uvicorn
 python-dotenv

--- a/phone-chatbot/daily-pstn-call-transfer/bot.py
+++ b/phone-chatbot/daily-pstn-call-transfer/bot.py
@@ -19,6 +19,7 @@ from pipecat.frames.frames import (
     EndTaskFrame,
     Frame,
     LLMMessagesAppendFrame,
+    LLMRunFrame,
     TranscriptionFrame,
 )
 from pipecat.pipeline.pipeline import Pipeline
@@ -460,7 +461,7 @@ async def run_bot(
     async def on_first_participant_joined(transport, participant):
         await transport.capture_participant_transcription(participant["id"])
         # For the dialin case, we want the bot to answer the phone and greet the user
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_dialout_answered")
     async def on_dialout_answered(transport, data):

--- a/phone-chatbot/daily-pstn-call-transfer/requirements.txt
+++ b/phone-chatbot/daily-pstn-call-transfer/requirements.txt
@@ -1,4 +1,4 @@
-pipecat-ai[daily,cartesia,openai,silero]
+pipecat-ai[daily,cartesia,openai,silero]>=0.0.82
 fastapi==0.115.6
 uvicorn
 python-dotenv

--- a/phone-chatbot/daily-pstn-dial-in/bot.py
+++ b/phone-chatbot/daily-pstn-dial-in/bot.py
@@ -18,6 +18,7 @@ import sys
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -159,7 +160,7 @@ async def run_bot(
     async def on_first_participant_joined(transport, participant):
         logger.debug(f"First participant joined: {participant['id']}")
         await transport.capture_participant_transcription(participant["id"])
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_participant_left")
     async def on_participant_left(transport, participant, reason):

--- a/phone-chatbot/daily-pstn-dial-in/requirements.txt
+++ b/phone-chatbot/daily-pstn-dial-in/requirements.txt
@@ -1,4 +1,4 @@
-pipecat-ai[daily,cartesia,openai,silero]
+pipecat-ai[daily,cartesia,openai,silero]>=0.0.82
 fastapi==0.115.6
 uvicorn
 python-dotenv

--- a/phone-chatbot/daily-twilio-sip-dial-in/bot.py
+++ b/phone-chatbot/daily-twilio-sip-dial-in/bot.py
@@ -8,6 +8,7 @@ import sys
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -104,7 +105,7 @@ async def run_bot(room_url: str, token: str, call_id: str, sip_uri: str) -> None
     async def on_first_participant_joined(transport, participant):
         logger.info(f"First participant joined: {participant['id']}")
         await transport.capture_participant_transcription(participant["id"])
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     # Handle participant leaving
     @transport.event_handler("on_participant_left")

--- a/phone-chatbot/daily-twilio-sip-dial-in/requirements.txt
+++ b/phone-chatbot/daily-twilio-sip-dial-in/requirements.txt
@@ -1,4 +1,4 @@
-pipecat-ai[daily,cartesia,openai,silero]
+pipecat-ai[daily,cartesia,openai,silero]>=0.0.82
 fastapi==0.115.6
 uvicorn
 python-dotenv

--- a/plivo-chatbot/bot.py
+++ b/plivo-chatbot/bot.py
@@ -12,6 +12,7 @@ from dotenv import load_dotenv
 from fastapi import WebSocket
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -96,7 +97,7 @@ async def run_bot(websocket_client: WebSocket, stream_id: str, call_id: Optional
     async def on_client_connected(transport, client):
         # Kick off the conversation.
         messages.append({"role": "system", "content": "Please introduce yourself to the user."})
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/plivo-chatbot/requirements.txt
+++ b/plivo-chatbot/requirements.txt
@@ -1,4 +1,4 @@
-pipecat-ai[cartesia,openai,silero,deepgram]
+pipecat-ai[cartesia,openai,silero,deepgram]>=0.0.82
 fastapi
 uvicorn
 python-dotenv

--- a/push-to-talk/server/bot.py
+++ b/push-to-talk/server/bot.py
@@ -12,6 +12,7 @@ from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.frames.frames import (
     Frame,
     InputAudioRawFrame,
+    LLMRunFrame,
     StartFrame,
     StartInterruptionFrame,
     StopInterruptionFrame,
@@ -157,7 +158,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         logger.info(f"Client connected")
         # Kick off the conversation.
         messages.append({"role": "system", "content": "Please introduce yourself to the user."})
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/push-to-talk/server/requirements.txt
+++ b/push-to-talk/server/requirements.txt
@@ -1,1 +1,1 @@
-pipecat-ai[daily,deepgram,openai,silero,cartesia,runner]>=0.0.79
+pipecat-ai[daily,deepgram,openai,silero,cartesia,runner]>=0.0.82

--- a/runner-examples/01-single-transport-bot.py
+++ b/runner-examples/01-single-transport-bot.py
@@ -18,6 +18,7 @@ import os
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -84,7 +85,7 @@ async def run_bot(transport: BaseTransport):
     async def on_client_connected(transport, client):
         logger.info("Client connected")
         messages.append({"role": "system", "content": "Say hello and briefly introduce yourself."})
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/runner-examples/02-two-transport-bot.py
+++ b/runner-examples/02-two-transport-bot.py
@@ -24,6 +24,7 @@ import os
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -89,7 +90,7 @@ async def run_bot(transport: BaseTransport):
     async def on_client_connected(transport, client):
         logger.info("Client connected")
         messages.append({"role": "system", "content": "Say hello and briefly introduce yourself."})
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/runner-examples/03-all-transport-bot.py
+++ b/runner-examples/03-all-transport-bot.py
@@ -20,6 +20,7 @@ import os
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -90,7 +91,7 @@ async def run_bot(transport: BaseTransport):
     async def on_client_connected(transport, client):
         logger.info("Client connected")
         messages.append({"role": "system", "content": "Say hello and briefly introduce yourself."})
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/runner-examples/04-all-transport-factory-bot.py
+++ b/runner-examples/04-all-transport-factory-bot.py
@@ -20,6 +20,7 @@ import os
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -126,7 +127,7 @@ async def run_bot(transport: BaseTransport):
     async def on_client_connected(transport, client):
         logger.info("Client connected")
         messages.append({"role": "system", "content": "Say hello and briefly introduce yourself."})
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/runner-examples/requirements.txt
+++ b/runner-examples/requirements.txt
@@ -1,1 +1,1 @@
-pipecat-ai[openai,daily,deepgram,cartesia,silero,webrtc,websocket,runner]>=0.0.80
+pipecat-ai[openai,daily,deepgram,cartesia,silero,webrtc,websocket,runner]>=0.0.82

--- a/sentry-metrics/bot.py
+++ b/sentry-metrics/bot.py
@@ -13,6 +13,7 @@ import sentry_sdk
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -95,7 +96,7 @@ async def main():
         @transport.event_handler("on_first_participant_joined")
         async def on_first_participant_joined(transport, participant):
             await transport.capture_participant_transcription(participant["id"])
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
+            await task.queue_frames([LLMRunFrame()])
 
         @transport.event_handler("on_participant_left")
         async def on_participant_left(transport, participant, reason):

--- a/sentry-metrics/requirements.txt
+++ b/sentry-metrics/requirements.txt
@@ -1,4 +1,4 @@
 python-dotenv
 fastapi[all]
 uvicorn
-pipecat-ai[daily,openai,sentry,silero,elevenlabs]
+pipecat-ai[daily,openai,sentry,silero,elevenlabs]>=0.0.82

--- a/simple-chatbot/server/bot-gemini.py
+++ b/simple-chatbot/server/bot-gemini.py
@@ -26,6 +26,7 @@ from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
     Frame,
+    LLMRunFrame,
     OutputImageRawFrame,
     SpriteFrame,
 )
@@ -157,7 +158,7 @@ async def run_bot(transport: BaseTransport):
     async def on_client_ready(rtvi):
         await rtvi.set_bot_ready()
         # Kick off the conversation
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, participant):

--- a/simple-chatbot/server/bot-openai.py
+++ b/simple-chatbot/server/bot-openai.py
@@ -27,6 +27,7 @@ from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
     Frame,
+    LLMRunFrame,
     OutputImageRawFrame,
     SpriteFrame,
 )
@@ -163,7 +164,7 @@ async def run_bot(transport: BaseTransport):
     async def on_client_ready(rtvi):
         await rtvi.set_bot_ready()
         # Kick off the conversation
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, participant):

--- a/simple-chatbot/server/requirements.txt
+++ b/simple-chatbot/server/requirements.txt
@@ -1,1 +1,1 @@
-pipecat-ai[daily,elevenlabs,openai,silero,google,runner]>=0.0.79
+pipecat-ai[daily,elevenlabs,openai,silero,google,runner]>=0.0.82

--- a/storytelling-chatbot/server/bot.py
+++ b/storytelling-chatbot/server/bot.py
@@ -13,7 +13,7 @@ import aiohttp
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import EndFrame
+from pipecat.frames.frames import EndFrame, LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -117,7 +117,7 @@ async def main(room_url, token=None):
             await main_task.queue_frames(
                 [
                     images["book1"],
-                    context_aggregator.user().get_context_frame(),
+                    LLMRunFrame(),
                     DailyTransportMessageFrame(CUE_USER_TURN),
                     # sounds["listening"],
                     images["book2"],

--- a/storytelling-chatbot/server/requirements.txt
+++ b/storytelling-chatbot/server/requirements.txt
@@ -2,4 +2,4 @@ async_timeout
 fastapi
 uvicorn
 python-dotenv
-pipecat-ai[daily,silero,openai,cartesia,google]
+pipecat-ai[daily,silero,openai,cartesia,google]>=0.0.82

--- a/studypal/requirements.txt
+++ b/studypal/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.12.3
 pypdf==4.3.1
 tiktoken==0.7.0
-pipecat-ai[daily,cartesia,openai,silero]
+pipecat-ai[daily,cartesia,openai,silero]>=0.0.82
 python-dotenv==1.0.1

--- a/studypal/studypal.py
+++ b/studypal/studypal.py
@@ -9,6 +9,7 @@ from bs4 import BeautifulSoup
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -170,7 +171,7 @@ Your task is to help the user understand and learn from this article in 2 senten
                     "content": "Hello! I'm ready to discuss the article with you. What would you like to learn about?",
                 }
             )
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
+            await task.queue_frames([LLMRunFrame()])
 
         @transport.event_handler("on_participant_left")
         async def on_participant_left(transport, participant, reason):

--- a/telnyx-chatbot/bot.py
+++ b/telnyx-chatbot/bot.py
@@ -10,6 +10,7 @@ import sys
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -100,7 +101,7 @@ async def run_bot(
     async def on_client_connected(transport, client):
         # Kick off the conversation.
         messages.append({"role": "system", "content": "Please introduce yourself to the user."})
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/telnyx-chatbot/requirements.txt
+++ b/telnyx-chatbot/requirements.txt
@@ -1,4 +1,4 @@
-pipecat-ai[openai,silero,deepgram,cartesia]
+pipecat-ai[openai,silero,deepgram,cartesia]>=0.0.82
 fastapi
 uvicorn
 python-dotenv

--- a/travel-companion/server/bot-gemini.py
+++ b/travel-companion/server/bot-gemini.py
@@ -24,6 +24,7 @@ from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.adapters.schemas.tools_schema import AdapterType, ToolsSchema
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.audio.vad.vad_analyzer import VADParams
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -169,7 +170,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_ready(rtvi):
         await rtvi.set_bot_ready()
         # Kick off the conversation
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/travel-companion/server/requirements.txt
+++ b/travel-companion/server/requirements.txt
@@ -1,1 +1,1 @@
-pipecat-ai[daily,openai,silero,google,runner]>=0.0.80
+pipecat-ai[daily,openai,silero,google,runner]>=0.0.82

--- a/twilio-chatbot/bot.py
+++ b/twilio-chatbot/bot.py
@@ -15,6 +15,7 @@ from dotenv import load_dotenv
 from fastapi import WebSocket
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -125,7 +126,7 @@ async def run_bot(websocket_client: WebSocket, stream_sid: str, call_sid: str, t
         await audiobuffer.start_recording()
         # Kick off the conversation.
         messages.append({"role": "system", "content": "Please introduce yourself to the user."})
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
     async def on_client_disconnected(transport, client):

--- a/twilio-chatbot/requirements.txt
+++ b/twilio-chatbot/requirements.txt
@@ -1,4 +1,4 @@
-pipecat-ai[cartesia,openai,silero,deepgram]
+pipecat-ai[cartesia,openai,silero,deepgram]>=0.0.82
 fastapi
 uvicorn
 python-dotenv

--- a/websocket/server/bot_fast_api.py
+++ b/websocket/server/bot_fast_api.py
@@ -9,6 +9,7 @@ import sys
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -95,7 +96,7 @@ async def run_bot(websocket_client):
         logger.info("Pipecat client ready.")
         await rtvi.set_bot_ready()
         # Kick off the conversation.
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @ws_transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):

--- a/websocket/server/bot_websocket_server.py
+++ b/websocket/server/bot_websocket_server.py
@@ -8,6 +8,7 @@ import os
 
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -88,7 +89,7 @@ async def run_bot_websocket_server():
         logger.info("Pipecat client ready.")
         await rtvi.set_bot_ready()
         # Kick off the conversation.
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @ws_transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):

--- a/websocket/server/requirements.txt
+++ b/websocket/server/requirements.txt
@@ -1,4 +1,4 @@
 python-dotenv
 fastapi[all]
 uvicorn
-pipecat-ai[silero,websocket,google]
+pipecat-ai[silero,websocket,google]>=0.0.82

--- a/word-wrangler-gemini-live/server/bot.py
+++ b/word-wrangler-gemini-live/server/bot.py
@@ -14,6 +14,7 @@ import aiohttp
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -146,7 +147,7 @@ Important guidelines:
         logger.debug("Client ready event received")
         await rtvi.set_bot_ready()
         # Kick off the conversation
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_first_participant_joined")
     async def on_first_participant_joined(transport, participant):

--- a/word-wrangler-gemini-live/server/bot_phone_local.py
+++ b/word-wrangler-gemini-live/server/bot_phone_local.py
@@ -36,6 +36,7 @@ from pipecat.frames.frames import (
     Frame,
     InputAudioRawFrame,
     LLMFullResponseEndFrame,
+    LLMRunFrame,
     LLMTextFrame,
     StartFrame,
     TTSAudioRawFrame,
@@ -689,7 +690,7 @@ Important guidelines:
     async def on_first_participant_joined(transport, participant):
         logger.info("First participant joined: {}", participant["id"])
         # Kick off the conversation
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
         # Start the game timer
         game_timer.start()
 

--- a/word-wrangler-gemini-live/server/bot_phone_twilio.py
+++ b/word-wrangler-gemini-live/server/bot_phone_twilio.py
@@ -32,6 +32,7 @@ from pipecat.frames.frames import (
     Frame,
     InputAudioRawFrame,
     LLMFullResponseEndFrame,
+    LLMRunFrame,
     LLMTextFrame,
     StartFrame,
     TTSAudioRawFrame,
@@ -706,7 +707,7 @@ Important guidelines:
     async def on_client_connected(transport, client):
         logger.info(f"Client connected: {client}")
         # Kick off the conversation
-        await task.queue_frames([context_aggregator.user().get_context_frame()])
+        await task.queue_frames([LLMRunFrame()])
         # Start the game timer
         game_timer.start()
 

--- a/word-wrangler-gemini-live/server/requirements.txt
+++ b/word-wrangler-gemini-live/server/requirements.txt
@@ -1,5 +1,5 @@
 pipecatcloud
-pipecat-ai[daily,google,silero]
+pipecat-ai[daily,google,silero]>=0.0.82
 fastapi
 uvicorn
 python-dotenv


### PR DESCRIPTION
With one exception: phone-chatbot/daily-pstn-advanced-voicemail-detection has a legit use-case for creating a context frame directly. That example has been updated to construct a `OpenAILLMContextFrame` rather than use the deprecated `get_context_frame()`.

NOTE: I did not exhaustively test every one of these examples. I tested a few to convince myself that the general upgrade pattern made sense.