### PR TITLE
Add custom data support to twilio-chatbot outbound example

### DIFF
--- a/twilio-chatbot/outbound/pyproject.toml
+++ b/twilio-chatbot/outbound/pyproject.toml
@@ -6,5 +6,6 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.84",
-  "pipecatcloud>=0.2.4"
+  "pipecatcloud>=0.2.4",
+  "twilio"
 ]


### PR DESCRIPTION
Updating twilio-chatbot outbound to show how to pass through custom data. This will be compatible with the runner in this update: https://github.com/pipecat-ai/pipecat/pull/2622.