### PR TITLE
Bump pipecat-ai version to .85 for telephony chatbots

### DIFF
--- a/exotel-chatbot/inbound/pyproject.toml
+++ b/exotel-chatbot/inbound/pyproject.toml
@@ -5,6 +5,6 @@ description = "Exotel dial-in example for Pipecat"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.84",
+  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.85",
   "pipecatcloud>=0.2.4"
 ]

--- a/exotel-chatbot/outbound/pyproject.toml
+++ b/exotel-chatbot/outbound/pyproject.toml
@@ -5,6 +5,6 @@ description = "Exotel dial-out example for Pipecat"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.84",
+  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.85",
   "pipecatcloud>=0.2.4"
 ]

--- a/plivo-chatbot/inbound/pyproject.toml
+++ b/plivo-chatbot/inbound/pyproject.toml
@@ -5,6 +5,6 @@ description = "Plivo dial-in example for Pipecat"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.84",
+  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.85",
   "pipecatcloud>=0.2.4"
 ]

--- a/plivo-chatbot/outbound/pyproject.toml
+++ b/plivo-chatbot/outbound/pyproject.toml
@@ -5,6 +5,6 @@ description = "Plivo dial-out example for Pipecat"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.84",
+  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.85",
   "pipecatcloud>=0.2.4"
 ]

--- a/telnyx-chatbot/inbound/pyproject.toml
+++ b/telnyx-chatbot/inbound/pyproject.toml
@@ -5,6 +5,6 @@ description = "Telnyx dial-in example for Pipecat"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.84",
+  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.85",
   "pipecatcloud>=0.2.4"
 ]

--- a/telnyx-chatbot/outbound/pyproject.toml
+++ b/telnyx-chatbot/outbound/pyproject.toml
@@ -5,6 +5,6 @@ description = "Telnyx dial-out example for Pipecat"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.84",
+  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.85",
   "pipecatcloud>=0.2.4"
 ]

--- a/twilio-chatbot/inbound/pyproject.toml
+++ b/twilio-chatbot/inbound/pyproject.toml
@@ -5,7 +5,7 @@ description = "Twilio dial-in example for Pipecat"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.84",
+  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.85",
   "pipecatcloud>=0.2.4",
   "twilio"
 ]

--- a/twilio-chatbot/outbound/pyproject.toml
+++ b/twilio-chatbot/outbound/pyproject.toml
@@ -5,7 +5,7 @@ description = "Twilio dial-out example for Pipecat"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.84",
+  "pipecat-ai[websocket,cartesia,openai,silero,deepgram,runner]>=0.0.85",
   "pipecatcloud>=0.2.4",
   "twilio"
 ]


### PR DESCRIPTION
Support the newest runner changes for the demos.