### PR TITLE
Langfuse session_id relocated

### DIFF
--- a/open-telemetry/langfuse/bot.py
+++ b/open-telemetry/langfuse/bot.py
@@ -142,7 +142,7 @@ async def run_bot(transport: BaseTransport):
         ),
         enable_tracing=IS_TRACING_ENABLED,
         # Optionally, add a conversation ID to track the conversation
-        # conversation_id="8df26cc1-6db0-4a7a-9930-1e037c8f1fa2",
+        # additional_span_attributes={"langfuse.session.id": "8df26cc1-6db0-4a7a-9930-1e037c8f1fa2"},
     )
 
     @transport.event_handler("on_client_connected")


### PR DESCRIPTION
Langfuse looks for session_id in the specific location only, proposed example enables correct handling of sessions in Langfuse dashboard