### PR TITLE
Bump push to talk Pipecat minimum version

### DIFF
--- a/push-to-talk/server/pyproject.toml
+++ b/push-to-talk/server/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Push to talk example"
 requires-python = ">=3.10"
 dependencies = [
-    "pipecat-ai[daily,deepgram,openai,silero,cartesia,runner]>=0.0.82",
+    "pipecat-ai[daily,deepgram,openai,silero,cartesia,runner]>=0.0.89",
     "pipecatcloud>=0.2.4"
 ]
 


### PR DESCRIPTION
Latest version that fixes the RTVI transport messaging issues from 0.0.87.