### PR TITLE
Update dial.js to use G722 instead of default PCMU/PCMA

### DIFF
--- a/deployment/pipecat-cloud-daily-pstn-server/fastapi-webhook-server/server.py
+++ b/deployment/pipecat-cloud-daily-pstn-server/fastapi-webhook-server/server.py
@@ -154,7 +154,7 @@ async def dial(request: RoomRequest, raw_request: Request):
             "display_name": request.From,
             "sip_mode": "dial-in",
             "num_endpoints": 2 if request.call_transfer is not None else 1,
-            "codecs": {"audio": ["OPUS"]},
+            "codecs": {"audio": ["G722"]}, # options are: ['OPUS', 'G722', 'PCMU', 'PCMA']
         }
         daily_room_properties["sip"] = sip_config
 

--- a/deployment/pipecat-cloud-daily-pstn-server/nextjs-webhook-server/pages/api/dial.js
+++ b/deployment/pipecat-cloud-daily-pstn-server/nextjs-webhook-server/pages/api/dial.js
@@ -104,7 +104,7 @@ export default async function handler(req, res) {
         display_name: From,
         sip_mode: 'dial-in',
         num_endpoints: (call_transfer !== undefined && call_transfer !== null) ? 2 : 1,
-        codecs: {"audio": ["OPUS"]},
+        codecs: {"audio": ["G722"]}, // options are: ['OPUS', 'G722', 'PCMU', 'PCMA']
       };
       daily_room_properties.sip = sip_config;
     }


### PR DESCRIPTION
Making a quick codec option change, this would ideally be on the environment or associated to a phone_number.

You can set any of the codecs, it will be have the highest priority, however, the system will fallback to PCMU/PCMA (G.711) codec if the chosen codec is not supported by the telecom operator.