### PR TITLE
Refactoring p2p video_transform example

### DIFF
--- a/p2p-webrtc/video-transform/server/server.py
+++ b/p2p-webrtc/video-transform/server/server.py
@@ -101,6 +101,7 @@ async def rtvi_start(request: Request):
 
     return result
 
+
 @app.api_route(
     "/sessions/{session_id}/{path:path}",
     methods=["GET", "POST", "PUT", "PATCH", "DELETE"],


### PR DESCRIPTION
Refactoring p2p video_transform example to use SmallWebRTCRequestHandler and provide start endpoint.