### PR TITLE
Update README with answerOnBridge attribute

### DIFF
--- a/phone-chatbot/daily-twilio-sip-dial-out/README.md
+++ b/phone-chatbot/daily-twilio-sip-dial-out/README.md
@@ -88,11 +88,12 @@ This example is organized to be production-ready and easy to customize:
    ```xml
    <?xml version="1.0" encoding="UTF-8"?>
    <Response>
-     <Dial callerId="+1234567890">{{#e164}}{{To}}{{/e164}}</Dial>
+     <Dial answerOnBridge="true" callerId="+1234567890">{{#e164}}{{To}}{{/e164}}</Dial>
    </Response>
    ```
 
    - callerId must be a valid number that you own on [Twilio](https://console.twilio.com/us1/develop/phone-numbers/manage/incoming)
+   - answerOnBridge="true|false" based on your use-case
    - Save the file. We will use this when creating the SIP domain
 
 4. Create and configure a SIP domain


### PR DESCRIPTION
Since this is back to back SIP sessions on Twilio. This should fix the potential issue that dialin-answered fires when twilio accepts the call instead it should fire when the remote party picks up the Twilio call. 

For example, the flow here is:
Daily SIP -> Twilio SIP -> Twilo dials to PSTN -> Remote User PSTN

when answerOnBridge = false (default value), the dialout-answered fires when Twilio accepts the call.

when answerOnBridge = true (this PR), the dialout-answered fires when Twilio thinks it accepted the call. 

The underlying issue is that SIP goes from INVITE sent (sent by Daily in dialoyt) -> 100 Trying (received from remote, `dialout-connected`) -> 180 RINGING (received from remote) -> 200 OK (received from remote) -> ACK (sent by Daily) -> media can flow.

`dialout-connected` is tied to `200 OK` state and reported by the remote. In this case, `answerOnBridge` forces Twilio to delay the `200 OK` message until the remote party answers otherwise Twilio just sends a `200 OK` while it is still setting up the call with the PSTN. 