### PR TITLE
Bump Pipecat Cloud SmallWebRTC example to use the latest transport version.

### DIFF
--- a/p2p-webrtc/pipecat-cloud/bot.py
+++ b/p2p-webrtc/pipecat-cloud/bot.py
@@ -39,6 +39,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         transport (BaseTransport): The transport to use for communication.
         runner_args: runner session arguments
     """
+    logger.info(f"RunnerArguments custom data: {runner_args.body}")
+
     # Configure your STT, LLM, and TTS services here
     # Swap out different processors or properties to customize your bot
     stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))

--- a/p2p-webrtc/pipecat-cloud/client/package-lock.json
+++ b/p2p-webrtc/pipecat-cloud/client/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@pipecat-ai/client-js": "^1.4.1",
-        "@pipecat-ai/small-webrtc-transport": "^1.7.0"
+        "@pipecat-ai/small-webrtc-transport": "^1.7.1"
       },
       "devDependencies": {
         "@types/node": "^22.13.1",
@@ -501,9 +501,9 @@
       }
     },
     "node_modules/@pipecat-ai/small-webrtc-transport": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.7.0.tgz",
-      "integrity": "sha512-yMBHWla22S3sIfo0kckyj6AJsZms3syRja1IDXc1NOC/v0iNVGlJ5EbeWrup5zJdVc4bc8JQ9kZYI5jQYP219Q==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/small-webrtc-transport/-/small-webrtc-transport-1.7.1.tgz",
+      "integrity": "sha512-oCNXlQEgYf9LY9k09IHKVGTo73NzrAlsUoUPWrO7mFlt9YfI81M2T0ZIjfkyhI3xiuUIL0L5yNmkrE30+vdU7A==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.83.1",

--- a/p2p-webrtc/pipecat-cloud/client/package.json
+++ b/p2p-webrtc/pipecat-cloud/client/package.json
@@ -19,6 +19,6 @@
   },
   "dependencies": {
     "@pipecat-ai/client-js": "^1.4.1",
-    "@pipecat-ai/small-webrtc-transport": "^1.7.0"
+    "@pipecat-ai/small-webrtc-transport": "^1.7.1"
   }
 }


### PR DESCRIPTION
Bump Pipecat Cloud SmallWebRTC example to use the latest transport version.