### PR TITLE
Add dial-in/out and DTMF event handlers to all phone bots

### DIFF
--- a/phone-chatbot/daily-pstn-cold-transfer/bot.py
+++ b/phone-chatbot/daily-pstn-cold-transfer/bot.py
@@ -260,13 +260,15 @@ async def bot(runner_args: RunnerArguments):
     token = body_data.get("token")
     call_id = body_data.get("callId")
     call_domain = body_data.get("callDomain")
+    from_phone = body_data.get("From")
+    to_phone = body_data.get("To")
 
     if not all([call_id, call_domain]):
         logger.error("Call ID and Call Domain are required in the body.")
         return None
 
     daily_dialin_settings = DailyDialinSettings(call_id=call_id, call_domain=call_domain)
-    logger.info(f"Starting dial-in bot, settings: {request.dialin_settings}")
+    logger.info(f"Starting dial-in bot, settings: call_id={call_id}, call_domain={call_domain}")
 
     transport = DailyTransport(
         room_url,
@@ -282,11 +284,11 @@ async def bot(runner_args: RunnerArguments):
 
     # Log caller information if available (which number is calling)
     # You can use this to look up customer information to personalize the conversation
-    if request.dialin_settings.From:
-        logger.info(f"Handling call from: {request.dialin_settings.From}")
+    if from_phone:
+        logger.info(f"Handling call from: {from_phone}")
     # Log callee information if available (which number was called)
     # You can use this to load different prompts based on which number was called
-    if request.dialin_settings.To:
-        logger.info(f"Handling call to: {request.dialin_settings.To}")
+    if to_phone:
+        logger.info(f"Handling call to: {to_phone}")
 
     await run_bot(transport, runner_args.handle_sigint)

--- a/phone-chatbot/daily-pstn-cold-transfer/bot.py
+++ b/phone-chatbot/daily-pstn-cold-transfer/bot.py
@@ -184,6 +184,27 @@ Available functions:
         # Bot answers the phone and greets the user
         await task.queue_frames([LLMRunFrame()])
 
+    @transport.event_handler("on_dialin_ready")
+    async def on_dialin_ready(transport, sip_endpoint):
+        logger.info(f"Dial-in ready: {sip_endpoint}")
+
+    @transport.event_handler("on_dialin_connected")
+    async def on_dialin_connected(transport, data):
+        logger.info(f"Dial-in connected: {data}")
+
+    @transport.event_handler("on_dialin_stopped")
+    async def on_dialin_stopped(transport, data):
+        logger.info(f"Dial-in stopped: {data}")
+
+    @transport.event_handler("on_dialin_warning")
+    async def on_dialin_warning(transport, data):
+        logger.warning(f"Dial-in warning: {data}")
+
+    @transport.event_handler("on_dialin_error")
+    async def on_dialin_error(transport, data):
+        logger.error(f"Dial-in error: {data}")
+        await task.cancel()
+
     @transport.event_handler("on_dialout_answered")
     async def on_dialout_answered(transport, data):
         logger.info(f"Operator answered, transferring call: {data}")
@@ -191,13 +212,33 @@ Available functions:
         # await task.cancel()
         await task.queue_frames([EndFrame()])
 
+    @transport.event_handler("on_dialout_connected")
+    async def on_dialout_connected(transport, data):
+        logger.info(f"Operator dial-out connected: {data}")
+
+    @transport.event_handler("on_dialout_stopped")
+    async def on_dialout_stopped(transport, data):
+        logger.info(f"Operator dial-out stopped: {data}")
+        # Inform the customer that transfer stopped
+        content = "I'm sorry, but I'm unable to connect you with a supervisor at this time. Is there anything else I can help you with?"
+        message = {"role": "user", "content": content}
+        await task.queue_frames([LLMMessagesAppendFrame([message], run_llm=True)])
+
+    @transport.event_handler("on_dialout_warning")
+    async def on_dialout_warning(transport, data):
+        logger.warning(f"Operator dial-out warning: {data}")
+
     @transport.event_handler("on_dialout_error")
     async def on_dialout_error(transport, data):
-        logger.error(f"Operator dialout error: {data}")
+        logger.error(f"Operator dial-out error: {data}")
         # Inform the customer that transfer failed
         content = "I'm sorry, but I'm unable to connect you with a supervisor at this time. Is there anything else I can help you with?"
         message = {"role": "user", "content": content}
         await task.queue_frames([LLMMessagesAppendFrame([message], run_llm=True)])
+
+    @transport.event_handler("on_dtmf_event")
+    async def on_dtmf_event(transport, data):
+        logger.info(f"DTMF event: {data}")
 
     @transport.event_handler("on_participant_left")
     async def on_participant_left(transport, participant, reason):
@@ -225,6 +266,7 @@ async def bot(runner_args: RunnerArguments):
         return None
 
     daily_dialin_settings = DailyDialinSettings(call_id=call_id, call_domain=call_domain)
+    logger.info(f"Starting dial-in bot, settings: {request.dialin_settings}")
 
     transport = DailyTransport(
         room_url,
@@ -237,5 +279,14 @@ async def bot(runner_args: RunnerArguments):
             audio_out_enabled=True,
         ),
     )
+
+    # Log caller information if available (which number is calling)
+    # You can use this to look up customer information to personalize the conversation
+    if request.dialin_settings.From:
+        logger.info(f"Handling call from: {request.dialin_settings.From}")
+    # Log callee information if available (which number was called)
+    # You can use this to load different prompts based on which number was called
+    if request.dialin_settings.To:
+        logger.info(f"Handling call to: {request.dialin_settings.To}")
 
     await run_bot(transport, runner_args.handle_sigint)

--- a/phone-chatbot/daily-pstn-dial-in/bot.py
+++ b/phone-chatbot/daily-pstn-dial-in/bot.py
@@ -106,10 +106,31 @@ async def run_bot(transport: BaseTransport, handle_sigint: bool) -> None:
         logger.info(f"Client disconnected")
         await task.cancel()
 
+    @transport.event_handler("on_dialin_ready")
+    async def on_dialin_ready(transport, sip_endpoint):
+        logger.info(f"Dial-in ready: {sip_endpoint}")
+
+    @transport.event_handler("on_dialin_connected")
+    async def on_dialin_connected(transport, data):
+        logger.info(f"Dial-in connected: {data}")
+
+    @transport.event_handler("on_dialin_stopped")
+    async def on_dialin_stopped(transport, data):
+        logger.info(f"Dial-in stopped: {data}")
+        await task.cancel()
+
+    @transport.event_handler("on_dialin_warning")
+    async def on_dialin_warning(transport, data):
+        logger.warning(f"Dial-in warning: {data}")
+
     @transport.event_handler("on_dialin_error")
     async def on_dialin_error(transport, data):
         logger.error(f"Dial-in error: {data}")
         await task.cancel()
+
+    @transport.event_handler("on_dtmf_event")
+    async def on_dtmf_event(transport, data):
+        logger.info(f"DTMF event: {data}")
 
     runner = PipelineRunner(handle_sigint=handle_sigint)
     await runner.run(task)
@@ -138,6 +159,7 @@ async def bot(runner_args: RunnerArguments):
             call_id=request.dialin_settings.call_id,
             call_domain=request.dialin_settings.call_domain,
         )
+        logger.info(f"Starting dial-in bot, settings: {request.dialin_settings}")
 
         transport = DailyTransport(
             runner_args.room_url,
@@ -152,10 +174,14 @@ async def bot(runner_args: RunnerArguments):
             ),
         )
 
-        # Log caller information if available
+        # Log caller information if available (which number is calling)
         # You can use this to look up customer information to personalize the conversation
         if request.dialin_settings.From:
             logger.info(f"Handling call from: {request.dialin_settings.From}")
+        # Log callee information if available (which number was called)
+        # You can use this to load different prompts based on which number was called
+        if request.dialin_settings.To:
+            logger.info(f"Handling call to: {request.dialin_settings.To}")
 
         await run_bot(transport, runner_args.handle_sigint)
 

--- a/phone-chatbot/daily-pstn-dial-out/bot.py
+++ b/phone-chatbot/daily-pstn-dial-out/bot.py
@@ -185,6 +185,23 @@ async def run_bot(
         logger.debug(f"Dial-out answered: {data}")
         dialout_manager.mark_successful()
 
+    @transport.event_handler("on_dialout_connected")
+    async def on_dialout_connected(transport, data):
+        logger.debug(f"Dial-out connected: {data}")
+
+    @transport.event_handler("on_dialout_stopped")
+    async def on_dialout_stopped(transport, data):
+        logger.debug(f"Dial-out stopped: {data}")
+        await task.cancel()
+
+    @transport.event_handler("on_dialout_warning")
+    async def on_dialout_warning(transport, data):
+        logger.warning(f"Dial-out warning: {data}")
+
+    @transport.event_handler("on_dtmf_event")
+    async def on_dtmf_event(transport, data):
+        logger.info(f"DTMF event: {data}")
+
     @transport.event_handler("on_dialout_error")
     async def on_dialout_error(transport, data: Any):
         logger.error(f"Dial-out error, retrying: {data}")

--- a/phone-chatbot/daily-pstn-dial-out/server_utils.py
+++ b/phone-chatbot/daily-pstn-dial-out/server_utils.py
@@ -108,7 +108,6 @@ async def create_daily_room(
     try:
         return await configure(
             session,
-            sip_caller_phone="Test",
             enable_dialout=True,
         )
     except Exception as e:

--- a/phone-chatbot/daily-pstn-warm-transfer/bot.py
+++ b/phone-chatbot/daily-pstn-warm-transfer/bot.py
@@ -439,24 +439,53 @@ async def run_bot(
 
     @transport.event_handler("on_dialout_connected")
     async def on_dialout_connected(transport, data) -> None:
-        logger.info(f"Dialout connected (ringing): {data}")
+        logger.info(f"Supervisor dial-out connected (ringing): {data}")
         # Stop hold music so customer hears the ringing
         await task.queue_frame(MixerEnableFrame(False))
 
     @transport.event_handler("on_dialout_answered")
     async def on_dialout_answered(transport, data) -> None:
-        logger.info(f"Dialout answered: {data}")
+        logger.info(f"Supervisor dial-out answered: {data}")
         await task.queue_frame(DialoutAnsweredFrame())
 
     @transport.event_handler("on_dialout_stopped")
     async def on_dialout_stopped(transport, data) -> None:
-        logger.info(f"Dialout stopped: {data}")
+        logger.info(f"Supervisor dial-out stopped: {data}")
         await task.queue_frame(DialoutStoppedFrame())
+
+    @transport.event_handler("on_dialout_warning")
+    async def on_dialout_warning(transport, data) -> None:
+        logger.warning(f"Supervisor dial-out warning: {data}")
 
     @transport.event_handler("on_dialout_error")
     async def on_dialout_error(transport, data) -> None:
-        logger.error(f"Dialout error: {data}")
+        logger.error(f"Supervisor dial-out error: {data}")
+
         await task.queue_frame(DialoutErrorFrame())
+
+    @transport.event_handler("on_dialin_ready")
+    async def on_dialin_ready(transport, sip_endpoint) -> None:
+        logger.info(f"Dial-in ready: {sip_endpoint}")
+
+    @transport.event_handler("on_dialin_connected")
+    async def on_dialin_connected(transport, data) -> None:
+        logger.info(f"Dial-in connected: {data}")
+
+    @transport.event_handler("on_dialin_stopped")
+    async def on_dialin_stopped(transport, data) -> None:
+        logger.info(f"Dial-in stopped: {data}")
+
+    @transport.event_handler("on_dialin_warning")
+    async def on_dialin_warning(transport, data) -> None:
+        logger.warning(f"Dial-in warning: {data}")
+
+    @transport.event_handler("on_dialin_error")
+    async def on_dialin_error(transport, data) -> None:
+        logger.error(f"Dial-in error: {data}")
+
+    @transport.event_handler("on_dtmf_event")
+    async def on_dtmf_event(transport, data) -> None:
+        logger.info(f"DTMF event: {data}")
 
     @transport.event_handler("on_participant_joined")
     async def on_participant_joined(transport, participant) -> None:

--- a/phone-chatbot/daily-twilio-sip-dial-in/bot.py
+++ b/phone-chatbot/daily-twilio-sip-dial-in/bot.py
@@ -118,6 +118,19 @@ async def run_bot(transport: BaseTransport, request: AgentRequest, handle_sigint
             logger.error(f"Failed to forward call: {str(e)}")
             await task.cancel()
 
+    @transport.event_handler("on_dialin_connected")
+    async def on_dialin_connected(transport, data):
+        logger.info(f"Dial-in connected: {data}")
+
+    @transport.event_handler("on_dialin_stopped")
+    async def on_dialin_stopped(transport, data):
+        logger.info(f"Dial-in stopped: {data}")
+        await task.cancel()
+
+    @transport.event_handler("on_dialin_warning")
+    async def on_dialin_warning(transport, data):
+        logger.warning(f"Dial-in warning: {data}")
+
     @transport.event_handler("on_dialin_error")
     async def on_dialin_error(transport, data):
         logger.error(f"Dial-in error: {data}")

--- a/phone-chatbot/daily-twilio-sip-dial-in/bot.py
+++ b/phone-chatbot/daily-twilio-sip-dial-in/bot.py
@@ -140,7 +140,9 @@ async def run_bot(transport: BaseTransport, request: AgentRequest, handle_sigint
     async def on_dtmf_event(transport, data):
         logger.info(f"DTMF event: {data}")
         # Echo back the DTMF tone to the caller
-        # await transport.send_dtmf({"tones": data["tone"], "digitDurationMs": 100})
+        # await transport._client.send_dtmf(
+        #     {"sessionId": data["sessionId"], "tones": data["tone"], "digitDurationMs": 100}
+        # )
 
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):

--- a/phone-chatbot/daily-twilio-sip-dial-in/bot.py
+++ b/phone-chatbot/daily-twilio-sip-dial-in/bot.py
@@ -140,7 +140,7 @@ async def run_bot(transport: BaseTransport, request: AgentRequest, handle_sigint
     async def on_dtmf_event(transport, data):
         logger.info(f"DTMF event: {data}")
         # Echo back the DTMF tone to the caller
-        # await transport.send_dtmf({"tones": data["tone"], "duration": 100})
+        # await transport.send_dtmf({"tones": data["tone"], "digitDurationMs": 100})
 
     @transport.event_handler("on_client_connected")
     async def on_client_connected(transport, client):

--- a/phone-chatbot/daily-twilio-sip-dial-out/bot.py
+++ b/phone-chatbot/daily-twilio-sip-dial-out/bot.py
@@ -195,7 +195,7 @@ async def run_bot(
     async def on_dtmf_event(transport, data):
         logger.info(f"DTMF event: {data}")
         # Echo back the DTMF tone to the caller
-        # await transport.send_dtmf({"tones": data["tone"], "duration": 100})
+        # await transport.send_dtmf({"tones": data["tone"], "digitDurationMs": 100})
 
     @transport.event_handler("on_dialout_error")
     async def on_dialout_error(transport, data: Any):

--- a/phone-chatbot/daily-twilio-sip-dial-out/bot.py
+++ b/phone-chatbot/daily-twilio-sip-dial-out/bot.py
@@ -195,7 +195,9 @@ async def run_bot(
     async def on_dtmf_event(transport, data):
         logger.info(f"DTMF event: {data}")
         # Echo back the DTMF tone to the caller
-        # await transport.send_dtmf({"tones": data["tone"], "digitDurationMs": 100})
+        # await transport._client.send_dtmf(
+        #     {"sessionId": data["sessionId"], "tones": data["tone"], "digitDurationMs": 100}
+        # )
 
     @transport.event_handler("on_dialout_error")
     async def on_dialout_error(transport, data: Any):

--- a/phone-chatbot/daily-twilio-sip-dial-out/server_utils.py
+++ b/phone-chatbot/daily-twilio-sip-dial-out/server_utils.py
@@ -110,7 +110,6 @@ async def create_daily_room(
     try:
         return await configure(
             session,
-            sip_caller_phone="dialout",
             enable_dialout=True,
             room_geo="us-east-1",  # can set this to the same region as your Twilio number
         )


### PR DESCRIPTION
## Summary

- Add full dial-in event handlers (`on_dialin_ready`, `on_dialin_connected`, `on_dialin_stopped`, `on_dialin_warning`, `on_dialin_error`) to all dial-in and transfer bots
- Add missing dial-out event handlers (`on_dialout_connected`, `on_dialout_stopped`, `on_dialout_warning`) to PSTN dial-out and cold-transfer bots
- Add `on_dialout_warning` to warm-transfer bot
- Add `on_dtmf_event` handler to all PSTN bots (Twilio bots already had it)
- Fix `on_dialin_ready` signature: use `sip_endpoint` param to match pipecat API
- Fix "Handling call from" to "Handling call to" for `To` field logging
- Fix `NameError` in cold-transfer bot where `request` was undefined
- Add caller/callee logging to cold-transfer bot
- Improve log prefixes in warm-transfer (e.g., "Supervisor dial-out connected")
- Remove `sip_caller_phone` workaround in dial-out bots (fixed in pipecat 0.0.107 via pipecat-ai/pipecat#4087)

## Test plan

- [x] Dial-in bots: verify all dial-in events are logged during a call
- [x] Dial-out bots: verify all dial-out events are logged during a call
- [ ] Transfer bots: verify both dial-in and dial-out events are logged
- [x] DTMF: press keypad during a call, verify DTMF events are logged
- [ ] Cold-transfer bot: verify no NameError on startup
- [x] Dial-out bots: verify rooms are created with enable_dialout without sip_caller_phone workaround (requires pipecat >= 0.0.107)