### PR TITLE
feat(bandwidth-chatbot): add inbound example for Bandwidth telephony

### DIFF
--- a/bandwidth-chatbot/inbound/README.md
+++ b/bandwidth-chatbot/inbound/README.md
@@ -1,0 +1,99 @@
+# Bandwidth Chatbot: Inbound
+
+A Pipecat-based voice agent that answers inbound phone calls on a
+[Bandwidth](https://www.bandwidth.com/) phone number. Uses Bandwidth's
+bidirectional WebSocket media streaming via the BXML `<StartStream>` verb,
+and OpenAI for the entire AI stack (Realtime STT + LLM + TTS).
+
+## Prerequisites
+
+### Bandwidth
+
+- A Bandwidth account on the Universal Platform with **Media Streaming enabled**
+  (it's an account-level add-on; check with your account rep if unsure).
+- OAuth 2.0 API credentials (Client ID + Client Secret) — generate in the
+  dashboard under API Credentials.
+- A voice-capable phone number assigned to a Voice Configuration Package (VCP)
+  whose linked voice application points its callback URL at this server.
+
+### AI services
+
+- An OpenAI API key. The example uses `OpenAIRealtimeSTTService`,
+  `OpenAILLMService`, and `OpenAITTSService`. To swap in faster providers
+  (Deepgram, Cartesia, etc.) for production-grade latency, edit `bot.py`.
+
+### Local tooling
+
+- Python 3.11+
+- `uv` package manager
+- `ngrok` (or any public-URL tunnel) for local development
+
+## Setup
+
+```sh
+cd inbound
+uv sync
+cp env.example .env
+# fill in OPENAI_API_KEY, BANDWIDTH_*, NGROK_PUBLIC_URL
+```
+
+## Local development
+
+1. **Start ngrok** in a separate terminal:
+
+   ```sh
+   ngrok http 8000
+   ```
+
+   Copy the HTTPS forwarding URL into `NGROK_PUBLIC_URL` in your `.env`.
+
+2. **Configure your Voice Application** in the Bandwidth dashboard (or via the
+   `band` CLI) so its `CallInitiatedCallbackUrl` points at
+   `https://<your-ngrok-host>/incoming-call`. Make sure the phone number's VCP
+   references that voice application.
+
+3. **Run the server**:
+
+   ```sh
+   uv run server.py
+   ```
+
+4. **Call your Bandwidth number.** The bot will greet you. The pipeline is
+   tuned for sub-second turn-around once the OpenAI sessions warm up; the
+   first response after process start takes ~3 seconds while sessions
+   initialize.
+
+## How it works
+
+Two endpoints in `server.py`:
+
+- `POST /incoming-call` — Bandwidth's voice app posts here on inbound calls.
+  We respond with BXML opening a bidirectional media stream:
+
+  ```xml
+  <Response>
+    <StartStream destination="wss://<ngrok>/ws" mode="bidirectional" tracks="inbound"/>
+    <Pause duration="86400"/>
+  </Response>
+  ```
+
+  The `<Pause>` keeps the call alive while the WebSocket runs.
+
+- `WebSocket /ws` — Bandwidth opens this and starts streaming audio. We
+  parse the first `start` event for `streamId` / `callId` / `accountId`,
+  instantiate `BandwidthFrameSerializer`, wire it to a
+  `FastAPIWebsocketTransport`, and run the Pipecat pipeline:
+
+  ```
+  WebSocket → STT → LLMUserAggregator → LLM → TTS → WebSocket → LLMAssistantAggregator
+  ```
+
+When the caller hangs up, the serializer terminates the call via the
+Bandwidth Voice API (OAuth client_credentials → Bearer → `POST /accounts/{id}/calls/{id}` with `state: completed`).
+
+## Audio quality
+
+The default uses PCMU 8kHz on the wire (matches Twilio/Telnyx parity). To
+take advantage of Bandwidth's higher-fidelity PCM outbound, pass
+`outbound_encoding="PCM"` and `outbound_pcm_sample_rate=24000` to
+`BandwidthFrameSerializer`.

--- a/bandwidth-chatbot/inbound/bot.py
+++ b/bandwidth-chatbot/inbound/bot.py
@@ -1,0 +1,126 @@
+#
+# Copyright (c) 2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Pipecat pipeline for the Bandwidth inbound chatbot example.
+
+Builds an OpenAI-only voice agent (realtime STT + LLM + TTS) that talks to a
+caller over a Bandwidth Programmable Voice WebSocket media stream.
+"""
+
+import os
+
+from fastapi import WebSocket
+from loguru import logger
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
+from pipecat.serializers.bandwidth import BandwidthFrameSerializer
+from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.services.openai.stt import OpenAIRealtimeSTTService
+from pipecat.services.openai.tts import OpenAITTSService
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
+
+
+async def run_bot(websocket: WebSocket, start_event: dict) -> None:
+    """Run the Pipecat pipeline for a single Bandwidth call.
+
+    Args:
+        websocket: FastAPI WebSocket already connected to Bandwidth.
+        start_event: The first JSON message from Bandwidth, which carries
+            ``metadata`` with ``streamId``, ``callId``, and ``accountId``.
+    """
+    metadata = start_event.get("metadata", {})
+    stream_id = metadata.get("streamId")
+    call_id = metadata.get("callId")
+    account_id = metadata.get("accountId") or os.getenv("BANDWIDTH_ACCOUNT_ID")
+    logger.info(f"Bandwidth call: stream={stream_id} call={call_id} account={account_id}")
+
+    serializer = BandwidthFrameSerializer(
+        stream_id=stream_id,
+        call_id=call_id,
+        account_id=str(account_id) if account_id else None,
+        client_id=os.getenv("BANDWIDTH_CLIENT_ID"),
+        client_secret=os.getenv("BANDWIDTH_CLIENT_SECRET"),
+    )
+
+    transport = FastAPIWebsocketTransport(
+        websocket=websocket,
+        params=FastAPIWebsocketParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+            add_wav_header=False,
+            serializer=serializer,
+        ),
+    )
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    llm = OpenAILLMService(
+        api_key=api_key,
+        settings=OpenAILLMService.Settings(
+            system_instruction=(
+                "You are a helpful voice assistant talking to someone on the phone. "
+                "Keep responses short and conversational. Your output is converted to "
+                "speech, so avoid special characters and markdown."
+            ),
+        ),
+    )
+    stt = OpenAIRealtimeSTTService(api_key=api_key)
+    tts = OpenAITTSService(api_key=api_key)
+
+    context = LLMContext()
+    user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+        context,
+        user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer()),
+    )
+
+    pipeline = Pipeline(
+        [
+            transport.input(),
+            stt,
+            user_aggregator,
+            llm,
+            tts,
+            transport.output(),
+            assistant_aggregator,
+        ]
+    )
+
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(
+            audio_in_sample_rate=8000,
+            # OpenAI TTS only outputs 24kHz. Run the pipeline at 24kHz on the
+            # output side; BandwidthFrameSerializer resamples down to 8kHz
+            # μ-law on the wire.
+            audio_out_sample_rate=24000,
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+    )
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        context.add_message(
+            {"role": "user", "content": "Greet the caller and ask how you can help."}
+        )
+        await task.queue_frames([LLMRunFrame()])
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        await task.cancel()
+
+    runner = PipelineRunner(handle_sigint=False)
+    await runner.run(task)

--- a/bandwidth-chatbot/inbound/env.example
+++ b/bandwidth-chatbot/inbound/env.example
@@ -1,0 +1,11 @@
+OPENAI_API_KEY=
+
+# Bandwidth OAuth 2.0 client credentials (required for hang-up functionality).
+# Generate in the Bandwidth dashboard under API Credentials.
+BANDWIDTH_CLIENT_ID=
+BANDWIDTH_CLIENT_SECRET=
+BANDWIDTH_ACCOUNT_ID=
+
+# Public URL where this server is reachable (e.g. an ngrok HTTPS forwarding
+# URL). Used to construct the StartStream destination in the BXML response.
+NGROK_PUBLIC_URL=

--- a/bandwidth-chatbot/inbound/pyproject.toml
+++ b/bandwidth-chatbot/inbound/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "bandwidth-chatbot-dial-in"
+version = "0.1.0"
+description = "Bandwidth dial-in example for Pipecat"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "pipecat-ai[websocket,openai,silero,local-smart-turn-v3]>=1.1.0",
+  "fastapi>=0.118.0",
+  "uvicorn>=0.32.0",
+  "python-dotenv>=1.0.0",
+]

--- a/bandwidth-chatbot/inbound/server.py
+++ b/bandwidth-chatbot/inbound/server.py
@@ -1,0 +1,99 @@
+#
+# Copyright (c) 2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""FastAPI server for the Bandwidth inbound chatbot example.
+
+Exposes two endpoints:
+
+- ``POST /incoming-call``: Bandwidth's Voice Application calls this when a
+  call arrives. We respond with BXML that opens a bidirectional media-stream
+  WebSocket back to ``/ws`` and parks the call with ``<Pause>`` so it stays
+  alive while the WebSocket runs.
+
+- ``WebSocket /ws``: Bandwidth's media-stream WebSocket. We read the first
+  ``start`` event to extract call metadata, then hand the connection to the
+  Pipecat pipeline.
+"""
+
+import json
+import os
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, Request, WebSocket
+from fastapi.responses import Response
+from loguru import logger
+
+from bot import run_bot
+
+load_dotenv(override=True)
+
+app = FastAPI()
+
+NGROK_PUBLIC_URL = os.environ["NGROK_PUBLIC_URL"]
+WS_DESTINATION = NGROK_PUBLIC_URL.replace("https://", "wss://").replace("http://", "ws://") + "/ws"
+
+
+@app.post("/incoming-call")
+async def incoming_call(request: Request) -> Response:
+    """Handle Bandwidth's inbound-call webhook with a BXML StartStream response."""
+    body = await request.body()
+    try:
+        payload = json.loads(body) if body else {}
+    except json.JSONDecodeError:
+        payload = {}
+    logger.info(
+        f"Incoming call: from={payload.get('from')} to={payload.get('to')} "
+        f"callId={payload.get('callId')}"
+    )
+
+    bxml = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        "<Response>"
+        f'<StartStream destination="{WS_DESTINATION}" mode="bidirectional" tracks="inbound"/>'
+        '<Pause duration="86400"/>'
+        "</Response>"
+    )
+    return Response(content=bxml, media_type="application/xml")
+
+
+@app.websocket("/ws")
+async def media_stream(websocket: WebSocket) -> None:
+    """Handle Bandwidth's bidirectional media-stream WebSocket."""
+    await websocket.accept()
+    logger.info("WebSocket accepted, waiting for start event")
+
+    # Bandwidth's first message is always the start event with call metadata.
+    raw = await websocket.receive_text()
+    try:
+        start_event = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.error(f"First WebSocket message wasn't JSON: {raw[:200]!r}")
+        await websocket.close()
+        return
+
+    if start_event.get("eventType") != "start":
+        logger.warning(f"First WebSocket message wasn't 'start', got: {start_event}")
+
+    logger.info(f"Start event: {json.dumps(start_event, indent=2)}")
+
+    try:
+        await run_bot(websocket, start_event)
+    except Exception as exc:
+        logger.exception(f"run_bot failed: {exc}")
+    finally:
+        if websocket.client_state.name != "DISCONNECTED":
+            await websocket.close()
+
+
+@app.get("/")
+async def root() -> dict:
+    return {"status": "ok", "ws_destination": WS_DESTINATION}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000, log_level="info")


### PR DESCRIPTION
## Summary

Adds a complete Pipecat voice agent example for Bandwidth Programmable Voice, mirroring the existing `twilio-chatbot`, `telnyx-chatbot`, etc. Uses Bandwidth's bidirectional WebSocket media streaming via the `<StartStream>` BXML verb.

## What's in it

- `bandwidth-chatbot/inbound/server.py` — FastAPI app exposing `POST /incoming-call` (returns BXML to open the media stream) and `WebSocket /ws` (accepts the bidirectional stream and runs the Pipecat pipeline)
- `bandwidth-chatbot/inbound/bot.py` — Pipeline construction. Uses an all-OpenAI stack (Realtime STT + LLM + TTS) so a single API key drives the whole bot. Easy to swap in Deepgram/Cartesia for production-grade latency.
- `bandwidth-chatbot/inbound/pyproject.toml`, `env.example`, `README.md` — companion files matching the existing telephony example layout

## Test plan

- [x] OAuth token fetch verified against live Bandwidth API
- [x] Hangup REST endpoint verified against live Bandwidth API (404 with correct error shape against fake call ID)
- [x] **End-to-end live phone call**: incoming-call BXML, WebSocket protocol parsing, audio in/out, multi-turn conversation, clean call termination. Tested against a real Bandwidth Universal Platform account with `<StartStream mode="bidirectional">`.
- [x] Bot speaks at correct sample rate (24kHz TTS resampled to 8kHz μ-law on the wire)

## Companion PRs

- Serializer: pipecat-ai/pipecat#4387 (`BandwidthFrameSerializer`)
- Docs: pipecat-ai/docs (API reference page for `BandwidthFrameSerializer`)

This example depends on the serializer PR landing first.

## Setup notes

- Requires a Bandwidth Universal Platform account with **Media Streaming enabled** (account-level entitlement)
- Voice Application's `CallInitiatedCallbackUrl` must point at `<your-public-url>/incoming-call`
- Number must be assigned to a VCP linked to that voice app