### PR TITLE
NVidia sagemaker example.

### DIFF
--- a/deployment/aws-sagemaker-nvidia/.gitignore
+++ b/deployment/aws-sagemaker-nvidia/.gitignore
@@ -1,0 +1,7 @@
+.venv
+.env
+/tmp/
+.claude/settings.local.json
+/client/tmp
+/client/.venv
+/client/uv.lock

--- a/deployment/aws-sagemaker-nvidia/DEPLOYMENT.md
+++ b/deployment/aws-sagemaker-nvidia/DEPLOYMENT.md
@@ -1,0 +1,338 @@
+# Deploying NVIDIA NIM Containers to AWS SageMaker
+
+This guide walks you through deploying NVIDIA NIM containers (Magpie TTS and Nemotron ASR Streaming) to SageMaker endpoints. Every step has an automation script — you should not need to type raw AWS CLI commands.
+
+---
+
+## Overview
+
+### Setup (run once, or when updating the NIM version / wrapper)
+```
+create_iam.sh       → IAM role + deployer user (requires AWS admin credentials)
+pull_nim.sh         → pull a NIM container from NVIDIA NGC
+build_wrapper.sh    → build the SageMaker wrapper on top of the local NIM image
+push_to_ecr.sh      → push the wrapper image to AWS ECR
+```
+
+### Deployment
+```
+create_model.sh     → register the wrapper image as a SageMaker Model
+create_endpoint.sh  → deploy the endpoint (waits for InService)
+```
+
+### Observability
+```
+logs_endpoint.sh    → stream live CloudWatch logs from the endpoint container
+list_endpoints.sh   → show all endpoints and their status
+```
+
+### Teardown
+```
+delete_endpoint.sh  → tear down an endpoint and its config
+delete_model.sh     → delete the SageMaker model
+```
+
+All scripts that operate on a specific NIM accept it as the first argument (`magpie` or `nemotron-asr`). If omitted, they prompt interactively.
+
+---
+
+## Prerequisites
+
+| Tool | Notes |
+|---|---|
+| Docker Desktop | Running locally |
+| AWS CLI v2 | [Install guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) |
+| Python 3.10+ | For Pipecat integration |
+| AWS admin account | Needed to run the IAM setup script once |
+| NVIDIA NGC API key | See Step 2 below |
+
+---
+
+## Environment Setup
+
+### 1. Copy the environment template
+
+```bash
+cp env.example .env
+```
+
+Fill in values as you go through the steps — the scripts will tell you what's missing.
+
+### 2. Get your NVIDIA NGC API key
+
+1. Go to [build.nvidia.com](https://build.nvidia.com) and create a free NVIDIA developer account.
+2. Generate an API key.
+3. Add it to `.env`:
+   ```
+   NGC_API_KEY=nvapi-xxxxxxxxxxxxxxxx
+   ```
+
+This key is used both to pull NIM containers from `nvcr.io` and by the NIM container at runtime to download model weights.
+
+### 3. Set your AWS region
+
+```
+AWS_REGION=us-west-2
+```
+
+---
+
+## Setup
+
+### Step 1 — Create IAM resources
+
+```bash
+./scripts/create_iam.sh
+```
+
+Run this **once**, as an AWS admin user (your personal `aws configure` credentials — not the deployer credentials, which don't exist yet).
+
+Creates:
+- **`magpie-sagemaker-execution-role`** — the IAM role SageMaker assumes when running endpoints. Needs ECR access to pull container images.
+- **`magpie-sagemaker-deployer`** — an IAM user with the minimum permissions to push to ECR and manage SageMaker models and endpoints.
+
+At the end, the script prints the deployer access keys. Add them to `.env`:
+
+```
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=...
+SAGEMAKER_EXECUTION_ROLE_ARN=arn:aws:iam::<ACCOUNT_ID>:role/magpie-sagemaker-execution-role
+```
+
+**Deployer permissions** — the `magpie-sagemaker-deployer` user has a single inline policy with only:
+
+| Permission group | Actions |
+|---|---|
+| ECR — authenticate | `ecr:GetAuthorizationToken` |
+| ECR — push image | `CreateRepository`, `DescribeRepositories`, `BatchCheckLayerAvailability`, `BatchGetImage`, `GetDownloadUrlForLayer`, `InitiateLayerUpload`, `UploadLayerPart`, `CompleteLayerUpload`, `PutImage` |
+| SageMaker — deploy | `CreateModel`, `DescribeModel`, `DeleteModel`, `CreateEndpointConfig`, `DescribeEndpointConfig`, `DeleteEndpointConfig`, `CreateEndpoint`, `DescribeEndpoint`, `DeleteEndpoint`, `InvokeEndpoint` |
+| IAM — pass role | `iam:PassRole` scoped to the execution role only |
+
+---
+
+### Step 2 — Pull the NIM container
+
+```bash
+./scripts/pull_nim.sh magpie             # Magpie TTS
+./scripts/pull_nim.sh nemotron-asr       # Nemotron ASR Streaming
+```
+
+Always pulls `linux/amd64` — the platform SageMaker GPU instances run on. Important on Apple Silicon, where Docker would otherwise pull the wrong architecture.
+
+Available image tags:
+- Magpie TTS: https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/magpie-tts-multilingual/tags
+- Nemotron ASR: https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/nemotron-asr-streaming/tags
+
+To pull a specific version, set `MAGPIE_IMAGE_TAG` or `NEMOTRON_ASR_IMAGE_TAG` in `.env`, or pass the tag as the second argument:
+
+```bash
+./scripts/pull_nim.sh magpie 1.7.0
+./scripts/pull_nim.sh nemotron-asr latest
+```
+
+---
+
+### Step 3 — Build the SageMaker wrapper
+
+```bash
+./scripts/build_wrapper.sh magpie
+./scripts/build_wrapper.sh nemotron-asr
+```
+
+Builds the wrapper image locally on top of the NIM image already in your local Docker cache. Does not re-pull from NVIDIA's registry. The script auto-detects the NIM entrypoint via `docker inspect` and bakes it in as a build-arg.
+
+The wrapper is a thin FastAPI application that runs alongside NIM inside the same container and translates SageMaker's expected interface into the NIM's actual API. See the wrapper READMEs for details:
+- [sagemaker-wrapper/magpie/README.md](sagemaker-wrapper/magpie/README.md)
+- [sagemaker-wrapper/nemotron-asr/README.md](sagemaker-wrapper/nemotron-asr/README.md)
+
+---
+
+### Step 4 — Push the wrapper to ECR
+
+```bash
+./scripts/push_to_ecr.sh magpie
+./scripts/push_to_ecr.sh nemotron-asr
+```
+
+Pushes only the wrapper image — that is the only image SageMaker needs. The first push uploads all layers (NIM + wrapper); subsequent pushes only upload layers that changed (wrapper changes only).
+
+At the end the script prints the ECR image URI — add it to `.env`:
+
+```
+# Magpie TTS
+ECR_MAGPIE_IMAGE_URI=<ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/magpie-tts-sagemaker:latest
+
+# Nemotron ASR
+ECR_ASR_IMAGE_URI=<ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/nemotron-asr-sagemaker:latest
+```
+
+---
+
+## Deployment — Magpie TTS
+
+### Step 1 — Create the SageMaker Model
+
+```bash
+./scripts/create_model.sh magpie
+```
+
+Registers the wrapper ECR image as a SageMaker Model. Passes runtime environment variables to the container:
+
+| Variable | Purpose |
+|---|---|
+| `NGC_API_KEY` | NIM downloads model weights using this key |
+| `NIM_HTTP_API_PORT` | NIM's internal HTTP port (default `9000`) |
+| `NIM_GRPC_API_PORT` | NIM's gRPC port (default `50051`) |
+
+Requires in `.env`: `ECR_MAGPIE_IMAGE_URI`, `SAGEMAKER_EXECUTION_ROLE_ARN`, `SAGEMAKER_MAGPIE_MODEL_NAME`, `NGC_API_KEY`.
+
+### Step 2 — Deploy the Endpoint
+
+```bash
+./scripts/create_endpoint.sh magpie
+```
+
+Creates the endpoint configuration and deploys the endpoint, then waits for it to become `InService`, polling every 30 seconds. If deployment fails, it prints the failure reason.
+
+Configurable via `.env`:
+
+| Variable | Default | Notes |
+|---|---|---|
+| `SAGEMAKER_MAGPIE_ENDPOINT_CONFIG_NAME` | `magpie-tts-config` | |
+| `SAGEMAKER_MAGPIE_ENDPOINT_NAME` | `magpie-tts-endpoint` | |
+| `SAGEMAKER_MAGPIE_INSTANCE_TYPE` | `ml.g6.2xlarge` | See instance table below |
+| `SAGEMAKER_MAGPIE_INSTANCE_COUNT` | `1` | |
+| `SAGEMAKER_CONTAINER_STARTUP_TIMEOUT` | `3600` | Seconds SageMaker waits for health checks to pass |
+
+**GPU instance options:**
+
+| Instance | GPU | VRAM | Notes |
+|---|---|---|---|
+| `ml.g6.2xlarge` | 1x L4 | 24 GB | **Recommended** — newer CUDA driver, lower cost |
+| `ml.g6.4xlarge` | 1x L4 | 24 GB | More CPU/RAM for concurrency |
+| `ml.g6.12xlarge` | 4x L4 | 96 GB | High-throughput production |
+| `ml.g5.2xlarge` | 1x A10G | 24 GB | May fail with NIM 1.7.0 — see CUDA note below |
+| `ml.g5.4xlarge` | 1x A10G | 24 GB | May fail with NIM 1.7.0 — see CUDA note below |
+
+> **CUDA driver note:** NIM 1.7.0 (Riva 2.15.0) requires CUDA 12.4+ on the host. `ml.g5` instances on SageMaker may ship an older CUDA driver that is missing the `cuCtxCreate_v4` symbol, causing `riva-deploy` to fail at startup. `ml.g6` instances (L4 GPU) ship newer drivers and are the recommended choice.
+
+> Can take more than **30 minutes** to be ready.
+
+### Step 3 — Validate the Endpoint
+
+```bash
+python client/test/test_magpie_http.py --endpoint <endpoint-name>
+python client/test/test_magpie_ws.py   --endpoint <endpoint-name>
+```
+
+See [client/README.md](client/README.md) for all available options.
+
+Synthesis parameters (all optional — set in `.env`):
+
+| Variable | Default | Notes |
+|---|---|---|
+| `MAGPIE_VOICE` | `Magpie-Multilingual.EN-US.Aria` | Voice name |
+| `MAGPIE_LANGUAGE_CODE` | `en-US` | Language code |
+| `MAGPIE_SAMPLE_RATE_HZ` | `22050` | Output sample rate |
+
+---
+
+## Deployment — Nemotron ASR Streaming
+
+### Step 1 — Create the SageMaker Model
+
+```bash
+./scripts/create_model.sh nemotron-asr
+```
+
+Registers the wrapper ECR image as a SageMaker Model. In addition to the common variables, this also injects `NIM_TAGS_SELECTOR=mode=str`, which is required to enable streaming mode in the Nemotron ASR NIM.
+
+Requires in `.env`: `ECR_ASR_IMAGE_URI`, `SAGEMAKER_EXECUTION_ROLE_ARN`, `SAGEMAKER_ASR_MODEL_NAME`, `NGC_API_KEY`.
+
+### Step 2 — Deploy the Endpoint
+
+```bash
+./scripts/create_endpoint.sh nemotron-asr
+```
+
+Configurable via `.env`:
+
+| Variable | Default | Notes |
+|---|---|---|
+| `SAGEMAKER_ASR_ENDPOINT_CONFIG_NAME` | `nemotron-asr-config` | |
+| `SAGEMAKER_ASR_ENDPOINT_NAME` | `nemotron-asr-endpoint` | |
+| `SAGEMAKER_ASR_INSTANCE_TYPE` | `ml.g6.2xlarge` | See instance table above |
+| `SAGEMAKER_ASR_INSTANCE_COUNT` | `1` | |
+| `SAGEMAKER_CONTAINER_STARTUP_TIMEOUT` | `3600` | Seconds SageMaker waits for health checks to pass |
+
+> Can take more than **30 minutes** to be ready.
+
+### Step 3 — Validate the Endpoint
+
+```bash
+python client/test/test_asr_ws.py --endpoint <endpoint-name> --audio /path/to/audio.wav
+```
+
+See [client/README.md](client/README.md) for all available options.
+
+Test parameters (all optional — defaults shown):
+
+| Variable | Default | Notes |
+|---|---|---|
+| `NEMOTRON_ASR_LANGUAGE_CODE` | `en-US` | BCP-47 language code |
+| `NEMOTRON_ASR_SAMPLE_RATE_HZ` | `16000` | PCM input sample rate (ignored for WAV) |
+
+---
+
+## Observability
+
+### Stream endpoint logs
+
+```bash
+./scripts/logs_endpoint.sh magpie             # follow mode (Ctrl+C to stop)
+./scripts/logs_endpoint.sh nemotron-asr
+./scripts/logs_endpoint.sh magpie --no-follow # print the last hour of logs and exit
+```
+
+SageMaker writes all container output (both NIM and the FastAPI wrapper) to CloudWatch Logs under `/aws/sagemaker/Endpoints/<endpoint-name>`. The script streams from that log group directly.
+
+Logs appear only after the container starts. During the initial deployment the log group may not exist yet — the script will tell you if that's the case.
+
+### List all endpoints
+
+```bash
+./scripts/list_endpoints.sh
+```
+
+Shows all endpoints in your region with their current status. Highlights any that are still deploying or have failed (with the failure reason).
+
+---
+
+## Teardown
+
+### Delete an endpoint
+
+```bash
+./scripts/delete_endpoint.sh magpie
+./scripts/delete_endpoint.sh nemotron-asr
+```
+
+Deletes the endpoint and its endpoint configuration.
+
+> Delete the endpoint when not in use to avoid ongoing charges. The ECR image and SageMaker model are not billed by uptime.
+
+### Delete a model
+
+```bash
+./scripts/delete_model.sh magpie
+./scripts/delete_model.sh nemotron-asr
+```
+
+Deletes the SageMaker Model object. Make sure the endpoint is deleted first.
+
+---
+
+## Next steps
+
+Once an endpoint is `InService`, head to the [client examples](client/README.md)
+to run test clients and Pipecat voice bots against the endpoint.

--- a/deployment/aws-sagemaker-nvidia/README.md
+++ b/deployment/aws-sagemaker-nvidia/README.md
@@ -1,0 +1,130 @@
+# NVIDIA Models on AWS SageMaker
+
+A practical guide and quickstart for deploying NVIDIA speech AI models (Magpie TTS and Nemotron ASR) to AWS SageMaker, and integrating them with [Pipecat](https://github.com/pipecat-ai/pipecat) for real-time voice applications.
+
+---
+
+## What is NVIDIA Nemotron Speech ASR?
+
+**ASR** stands for *Automatic Speech Recognition* — it converts spoken audio into text.
+
+NVIDIA's **Nemotron Speech ASR** is a state-of-the-art speech recognition model optimized to run on NVIDIA GPUs. It is fast, accurate, and supports multiple languages. Think of it as the "ears" of a voice AI application: it listens to what a user says and turns it into words your application can understand.
+
+- Delivered as a **NIM** (NVIDIA Inference Microservice) — a pre-packaged Docker container that is production-ready out of the box.
+- Exposes a REST and WebSocket API on port 9000, and a gRPC API on port 50051.
+- Supports real-time streaming transcription via WebSocket (`/v1/realtime?intent=transcription`).
+- The **Streaming** variant (`nemotron-asr-streaming`) supports streaming mode only.
+
+## What is NVIDIA Nemotron Magpie TTS?
+
+**TTS** stands for *Text-to-Speech* — it converts text into spoken audio.
+
+**NVIDIA Magpie TTS** (`magpie-tts-multilingual`) is a high-quality, low-latency speech synthesis model built on top of NVIDIA Riva. It can produce natural-sounding voices in multiple languages and is optimized for real-time streaming — meaning audio starts playing before the full sentence is generated.
+
+- Also delivered as a **NIM** container.
+- Latest version: `1.7.0` (based on Riva 2.15.0).
+- Supports bidirectional streaming for ultra-low latency.
+
+## What is a NIM?
+
+A **NIM (NVIDIA Inference Microservice)** is a ready-to-deploy Docker container that bundles:
+- The model weights
+- An optimized inference runtime (TensorRT, Triton, etc.)
+- A standard API (OpenAI-compatible or gRPC)
+
+You pull it, configure it, and run it — no ML expertise required to get a production-grade endpoint.
+
+## What is AWS SageMaker?
+
+**AWS SageMaker** is Amazon's managed platform for deploying machine learning models at scale. Instead of managing your own GPU servers, SageMaker lets you:
+
+- Deploy a Docker container as a scalable HTTPS endpoint.
+- Choose from dozens of GPU instance types (e.g., `ml.g5.2xlarge`).
+- Pay only for what you use.
+- Get built-in monitoring, auto-scaling, and security.
+
+In short: SageMaker handles the infrastructure so you can focus on your application.
+
+---
+
+## Project Goal
+
+> Deploy NVIDIA Magpie TTS and Nemotron ASR to AWS SageMaker using official NIM containers, and connect them to a Pipecat voice pipeline.
+
+### Why not use the AWS Marketplace listing?
+
+There is a Magpie TTS listing on the AWS Marketplace, but it ships with **Riva 1.10.0** — a significantly older version. The NIM container on NVIDIA NGC uses **Riva 2.15.0**, which has better performance, more voices, and improved streaming support. This project deploys the up-to-date version directly.
+
+---
+
+## Architecture Overview
+
+```
+User Audio → Pipecat Pipeline
+                 │
+                 ├── ASR Service → Nemotron Speech (SageMaker Endpoint)
+                 │                     converts speech to text
+                 │
+                 ├── LLM Service → OpenAILLMService (Nemotron Super 120B — Modal hosted)
+                 │                     generates a response
+                 │
+                 └── TTS Service → NvidiaSageMakerTTSService (Magpie TTS — SageMaker)
+                                       converts text back to speech  ← this project
+```
+
+STT uses NVIDIA's hosted API at `build.nvidia.com` (requires `NVIDIA_API_KEY`).
+LLM uses a Nemotron Super 120B model hosted on Modal (configured via `NEMOTRON_LLM_BASE_URL`).
+Only the TTS service is deployed to SageMaker by this project.
+
+---
+
+## Prerequisites
+
+- An **AWS account** with permissions to use ECR, SageMaker, and IAM.
+- An **NVIDIA NGC API key** — get one free at [build.nvidia.com](https://build.nvidia.com).
+- **Docker** installed locally.
+- **AWS CLI** configured (`aws configure`).
+- Python 3.10+ and `uv` (or `pip`) for the Pipecat integration.
+
+---
+
+## Deploying
+
+All deployment steps are automated with shell scripts in `scripts/`. The full walkthrough is in **[DEPLOYMENT.md](DEPLOYMENT.md)**.
+
+See **[DEPLOYMENT.md](DEPLOYMENT.md)** for configuration options, instance types, and Pipecat integration.
+
+Once the endpoint is `InService`, test it and run the voice bot — see **[client/README.md](client/README.md)**.
+
+---
+
+## Quick Links
+
+| Resource | URL |
+|---|---|
+| Deployment guide | [DEPLOYMENT.md](DEPLOYMENT.md) |
+| Client examples & voice bot | [client/README.md](client/README.md) |
+| Magpie TTS wrapper | [sagemaker-wrapper/magpie/](sagemaker-wrapper/magpie/) |
+| Nemotron ASR wrapper | [sagemaker-wrapper/nemotron-asr/](sagemaker-wrapper/nemotron-asr/) |
+| AWS SageMaker console | https://console.aws.amazon.com/sagemaker/home#/endpoints |
+
+---
+
+## References
+
+| Resource                                             | URL |
+|------------------------------------------------------|---|
+| Magpie TTS NIM deploy guide                          | https://build.nvidia.com/nvidia/magpie-tts-multilingual/deploy |
+| Magpie NIM container tags                            | https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/magpie-tts-multilingual/tags |
+| NVIDIA TTS NIM DOCS                                  | https://docs.nvidia.com/nim/speech/latest/tts/index.html |
+| NVIDIA TTS client source code                        | https://github.com/nvidia-riva/python-clients/blob/main/riva/client/realtime.py |
+| NVIDIA TTS NIM GetStarted                            | https://docs.nvidia.com/nim/speech/latest/get-started/tutorials/tts.html#step-4-synthesize-speech |
+| NVIDIA NIM TTS Realtime API — Client & Server Events | https://docs.nvidia.com/nim/speech/latest/reference/api-references/tts/realtime-tts.html#list-of-client-events|
+| Nemotron ASR NIM deploy guide                        | https://build.nvidia.com/nvidia/nemotron-asr-streaming/deploy |
+| Nemotron ASR NIM deploy docs                         | https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/nemotron-asr-streaming.html |
+| NVIDIA NIM ASR Realtime API — Client & Server Events | https://docs.nvidia.com/nim/speech/latest/reference/api-references/asr/realtime-asr.html |
+| NVIDIA ASR client source code                        | https://github.com/nvidia-riva/python-clients/blob/main/scripts/asr/transcribe_file.py |
+| AWS SageMaker — bidirectional streaming docs         | https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html |
+
+---
+

--- a/deployment/aws-sagemaker-nvidia/client/Dockerfile
+++ b/deployment/aws-sagemaker-nvidia/client/Dockerfile
@@ -1,0 +1,18 @@
+FROM dailyco/pipecat-base:latest
+
+# Enable bytecode compilation for faster startup
+ENV UV_COMPILE_BYTECODE=1
+
+# Copy from the cache instead of linking since it's a mounted volume
+ENV UV_LINK_MODE=copy
+
+# Install dependencies using the lockfile
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project --no-dev
+
+# Copy bot implementation flat into the working directory so that the `services`
+# package is importable, then create the bot.py entry point Pipecat Cloud expects
+COPY ./bot/ ./
+RUN ln -s pipecat-bot-ws.py bot.py

--- a/deployment/aws-sagemaker-nvidia/client/README.md
+++ b/deployment/aws-sagemaker-nvidia/client/README.md
@@ -1,0 +1,273 @@
+# Client Examples
+
+This directory contains Python test clients and Pipecat voice bots for the
+Magpie TTS and Nemotron ASR SageMaker endpoints.
+
+All examples load credentials from `client/.env`.
+Copy `env.example` and fill it in before running anything here.
+
+---
+
+## Prerequisites
+
+- Python 3.12+
+- [`uv`](https://docs.astral.sh/uv/) (recommended) or `pip`
+- A running SageMaker endpoint — see [DEPLOYMENT.md](../DEPLOYMENT.md)
+
+### Install dependencies
+
+```bash
+cd client
+uv sync
+```
+
+### Configure credentials
+
+The examples read from `client/.env`. If you haven't set it up yet:
+
+```bash
+# From the client/ directory
+cp env.example .env
+# Fill in: AWS credentials, endpoint names and LLM base URL.
+```
+
+---
+
+## Two transport modes
+
+This project supports two ways to call a SageMaker endpoint:
+
+| Mode | SageMaker API | Wrapper endpoint | Best for |
+|---|---|---|---|
+| **HTTP** | `invoke-endpoint` | `POST /invocations` | Simple testing, batch requests |
+| **WebSocket / bidi-stream** | `invoke-endpoint-with-bidirectional-stream` | `WS /invocations-bidirectional-stream` | Real-time streaming, low latency |
+
+> **Note:** The bidi-stream API uses a separate SageMaker runtime endpoint on
+> port 8443 (`runtime.sagemaker.<region>.amazonaws.com:8443`), distinct from
+> the standard `invoke-endpoint` URL.
+
+---
+
+## Files
+
+| File | NIM | Mode | Purpose |
+|---|---|---|---|
+| `test/test_magpie_http.py` | Magpie TTS | HTTP | Send text, save audio as WAV |
+| `test/test_magpie_ws.py` | Magpie TTS | WebSocket | Send text via bidi-stream, save audio as WAV |
+| `test/test_asr_ws.py` | Nemotron ASR | WebSocket | Stream audio via bidi-stream, print transcript |
+| `bot/services/nim_sagemaker_http_tts.py` | Magpie TTS | HTTP | `NvidiaSageMakerHTTPTTSService` — Pipecat TTS service |
+| `bot/services/nim_sagemaker_ws_tts.py` | Magpie TTS | WebSocket | `NvidiaSageMakerWebsocketTTSService` — Pipecat TTS service |
+| `bot/services/nim_sagemaker_ws_stt.py` | Nemotron ASR | WebSocket | `NvidiaSageMakerWebsocketSTTService` — Pipecat STT service |
+| `bot/pipecat-bot-http.py` | Magpie TTS | HTTP | Full Pipecat voice bot (STT → LLM → TTS over HTTP) |
+| `bot/pipecat-bot-ws.py` | Magpie TTS | WebSocket | Full Pipecat voice bot (STT → LLM → TTS over bidi-stream) |
+
+---
+
+## Magpie TTS — HTTP test client
+
+Calls `POST /invocations`, receives raw PCM, and saves it as a WAV file.
+
+```bash
+# From the client/ directory:
+uv run test/test_magpie_http.py
+uv run test/test_magpie_http.py --text "Hello from SageMaker."
+```
+
+Options:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--endpoint` | `$SAGEMAKER_MAGPIE_ENDPOINT_NAME` | SageMaker endpoint name |
+| `--text` | (built-in phrase) | Text to synthesize |
+| `--voice` | `$MAGPIE_VOICE` | NIM voice name |
+| `--language` | `$MAGPIE_LANGUAGE_CODE` | BCP-47 language code |
+| `--sample-rate` | `$MAGPIE_SAMPLE_RATE_HZ` | Output sample rate in Hz |
+| `--output` | `./tmp/magpie-test.wav` | Output WAV file path |
+
+---
+
+## Magpie TTS — WebSocket test client
+
+Calls the bidi-stream endpoint via SageMaker's HTTP/2
+`InvokeEndpointWithBidirectionalStream` API. Audio chunks arrive as
+base64-encoded `conversation.item.speech.data` events and are assembled into
+a WAV file.
+
+```bash
+# From the client/ directory:
+uv run test/test_magpie_ws.py
+uv run test/test_magpie_ws.py --text "Hello from the bidi-stream endpoint." --output ./tmp/bidi-test.wav
+```
+
+Options:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--endpoint` | `$SAGEMAKER_MAGPIE_ENDPOINT_NAME` | SageMaker endpoint name |
+| `--region` | `$AWS_REGION` | AWS region |
+| `--text` | (built-in phrase) | Text to synthesize |
+| `--voice` | `$MAGPIE_VOICE` | NIM voice name |
+| `--language` | `$MAGPIE_LANGUAGE_CODE` | BCP-47 language code |
+| `--sample-rate` | `$MAGPIE_SAMPLE_RATE_HZ` | Output sample rate in Hz |
+| `--output` | `./tmp/magpie-bidi-test.wav` | Output WAV file path |
+
+---
+
+## Nemotron ASR — WebSocket test client
+
+Streams audio to the bidi-stream endpoint via SageMaker's HTTP/2
+`InvokeEndpointWithBidirectionalStream` API. Audio is sent as base64-encoded
+PCM16 chunks via `input_audio_buffer.append` events, and the transcript is
+collected from `conversation.item.input_audio_transcription.completed`.
+
+Falls back to `./tmp/magpie-test.pcm` if no audio is provided.
+
+```bash
+# From the client/ directory:
+uv run test/test_asr_ws.py
+uv run test/test_asr_ws.py --audio /path/to/audio.wav
+uv run test/test_asr_ws.py --audio /path/to/audio.pcm --language en-US
+```
+
+Options:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--endpoint` | `$SAGEMAKER_ASR_ENDPOINT_NAME` | SageMaker endpoint name |
+| `--audio` | `./tmp/magpie-test.pcm` | Audio file (.wav or raw PCM16) |
+| `--language` | `$NEMOTRON_ASR_LANGUAGE_CODE` | BCP-47 language code |
+| `--sample-rate` | `$NEMOTRON_ASR_SAMPLE_RATE_HZ` | PCM sample rate (ignored for WAV) |
+
+---
+
+## Pipecat HTTP voice bot — `bot/pipecat-bot-http.py`
+
+A complete real-time voice agent using HTTP synthesis:
+
+```
+Microphone → NvidiaSTTService              (Nemotron ASR — NVIDIA hosted API)
+           → OpenAILLMService              (Nemotron Super 120B — Modal hosted)
+           → NvidiaSageMakerHTTPTTSService (Magpie TTS — SageMaker)
+           → Speaker
+```
+
+> STT calls NVIDIA's hosted API at `build.nvidia.com`. LLM calls Nemotron
+> Super 120B hosted on Modal (`NEMOTRON_LLM_BASE_URL`). Only TTS uses the
+> SageMaker endpoint built by this project.
+
+```bash
+# From the client/ directory:
+uv run bot/pipecat-bot-http.py
+```
+
+### Required environment variables
+
+| Variable | Used by | Description |
+|---|---|---|
+| `AWS_ACCESS_KEY_ID` | TTS | AWS IAM credentials |
+| `AWS_SECRET_ACCESS_KEY` | TTS | AWS IAM credentials |
+| `AWS_REGION` | TTS | AWS region of the endpoint |
+| `SAGEMAKER_MAGPIE_ENDPOINT_NAME` | TTS | Deployed Magpie endpoint name |
+| `NVIDIA_API_KEY` | STT | NVIDIA build.nvidia.com API key |
+| `NEMOTRON_LLM_BASE_URL` | LLM | Base URL for the Nemotron Super Modal endpoint |
+
+---
+
+## Pipecat WebSocket voice bot — `bot/pipecat-bot-ws.py`
+
+A complete real-time voice agent where both STT and TTS run on SageMaker via
+bidirectional streaming. All three services maintain **persistent connections**
+for the lifetime of the pipeline, enabling low latency and clean interruption
+handling:
+
+```
+Microphone → NvidiaSageMakerWebsocketSTTService  (Nemotron ASR — SageMaker)
+           → OpenAILLMService                    (Nemotron Super 120B — Modal hosted)
+           → NvidiaSageMakerWebsocketTTSService  (Magpie TTS — SageMaker)
+           → Speaker
+```
+
+```bash
+# From the client/ directory:
+uv run bot/pipecat-bot-ws.py
+```
+
+### Required environment variables
+
+| Variable | Used by | Description |
+|---|---|---|
+| `AWS_ACCESS_KEY_ID` | STT + TTS | AWS IAM credentials |
+| `AWS_SECRET_ACCESS_KEY` | STT + TTS | AWS IAM credentials |
+| `AWS_REGION` | STT + TTS | AWS region of the endpoints |
+| `SAGEMAKER_ASR_ENDPOINT_NAME` | STT | Deployed Nemotron ASR endpoint name |
+| `SAGEMAKER_MAGPIE_ENDPOINT_NAME` | TTS | Deployed Magpie endpoint name |
+| `NEMOTRON_LLM_BASE_URL` | LLM | Base URL for the Nemotron Super Modal endpoint |
+
+---
+
+## Deploying to Pipecat Cloud
+
+`bot/pipecat-bot-ws.py` is ready to deploy to [Pipecat Cloud](https://pipecat.cloud).
+The project includes a `Dockerfile` and `pcc-deploy.toml` that Pipecat Cloud uses
+to build and run the bot.
+
+### Prerequisites
+
+- A [Pipecat Cloud](https://pipecat.cloud) account
+- Both SageMaker endpoints (`SAGEMAKER_ASR_ENDPOINT_NAME`, `SAGEMAKER_MAGPIE_ENDPOINT_NAME`) deployed and `InService`
+
+### Step 1 — Install the Pipecat CLI
+
+```bash
+uv tool install pipecat-ai-cli
+```
+
+### Step 2 — Authenticate
+
+```bash
+pipecat cloud auth login
+```
+
+### Step 3 — Install dependencies
+
+The `Dockerfile` uses `uv.lock` to install dependencies reproducibly. Generate it
+from the `client/` directory:
+
+```bash
+uv sync
+```
+
+### Step 4 — Upload secrets
+
+Upload your `.env` as a named secret set. Pipecat Cloud injects these as
+environment variables at runtime:
+
+```bash
+pipecat cloud secrets set nvidia-nim-secrets --file .env
+```
+
+The secret set name `nvidia-nim-secrets` matches what is configured in
+`pcc-deploy.toml`.
+
+### Step 5 — Deploy
+
+```bash
+pipecat cloud deploy
+```
+
+This builds the Docker image, pushes it to Pipecat Cloud, and starts the agent.
+The `pcc-deploy.toml` configures the agent name, secret set, and scaling:
+
+```toml
+agent_name = "nvidia-nim-bot"
+secret_set = "nvidia-nim-secrets"
+agent_profile = "agent-1x"
+
+[scaling]
+    min_agents = 1
+```
+
+### Step 6 — Connect
+
+Go to the [Pipecat Cloud Dashboard](https://pipecat.daily.co/) → your agent →
+**Sandbox** → **Connect** to open a browser-based WebRTC call with the bot.

--- a/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-http.py
+++ b/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-http.py
@@ -21,10 +21,10 @@ from pipecat.processors.aggregators.llm_response_universal import (
 )
 from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
+from pipecat.services.nvidia.sagemaker.stt import NvidiaSageMakerWebsocketSTTService
+from pipecat.services.nvidia.sagemaker.tts import NvidiaSageMakerHTTPTTSService
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
-from pipecat.services.nvidia.sagemaker.tts import NvidiaSageMakerHTTPTTSService
-from pipecat.services.nvidia.sagemaker.stt import NvidiaSageMakerWebsocketSTTService
 
 load_dotenv(override=True)
 

--- a/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-http.py
+++ b/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-http.py
@@ -21,7 +21,7 @@ from pipecat.processors.aggregators.llm_response_universal import (
 )
 from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
-from pipecat.services.nvidia.sagemaker.stt import NvidiaSageMakerWebsocketSTTService
+from pipecat.services.nvidia.sagemaker.stt import NvidiaSageMakerSTTService
 from pipecat.services.nvidia.sagemaker.tts import NvidiaSageMakerHTTPTTSService
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
@@ -41,7 +41,7 @@ transport_params = {
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info(f"Starting bot")
 
-    stt = NvidiaSageMakerWebsocketSTTService(
+    stt = NvidiaSageMakerSTTService(
         endpoint_name=os.getenv("SAGEMAKER_ASR_ENDPOINT_NAME"),
         region=os.getenv("AWS_REGION", "us-west-2"),
     )

--- a/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-http.py
+++ b/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-http.py
@@ -99,7 +99,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
-        context.add_message({"role": "developer", "content": "Please introduce yourself to the user."})
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")

--- a/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-http.py
+++ b/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-http.py
@@ -21,9 +21,9 @@ from pipecat.processors.aggregators.llm_response_universal import (
 )
 from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
+from pipecat.services.aws.llm import AWSBedrockLLMService, AWSBedrockLLMSettings
 from pipecat.services.nvidia.sagemaker.stt import NvidiaSageMakerSTTService
 from pipecat.services.nvidia.sagemaker.tts import NvidiaSageMakerHTTPTTSService
-from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 
 load_dotenv(override=True)
@@ -46,20 +46,11 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         region=os.getenv("AWS_REGION", "us-west-2"),
     )
 
-    llm = OpenAILLMService(
-        api_key="not_needed",
-        base_url=os.getenv("NEMOTRON_LLM_BASE_URL"),
-        model="nemotron-3-super-120b",
-        system_instruction="You are a real-time AI voice assistant. Keep responses short and sharp. Use plain speech and quick sentences. Avoid any symbols, emojis or formatting. Show usefulness in as few words as possible. Keep you response simple, maximum of 40 words each.",
-        params=OpenAILLMService.InputParams(
-            temperature=0.0,
-            extra={
-                "extra_body": {
-                    "chat_template_kwargs": {
-                        "enable_thinking": False,
-                    }
-                }
-            },
+    llm = AWSBedrockLLMService(
+        aws_region=os.getenv("AWS_REGION"),
+        settings=AWSBedrockLLMSettings(
+            model="nvidia.nemotron-super-3-120b",
+            system_instruction="You are a real-time AI voice assistant. Keep responses short and sharp. Use plain speech and quick sentences. Avoid any symbols, emojis or formatting. Show usefulness in as few words as possible. Keep you response simple, maximum of 40 words each.",
         ),
     )
 

--- a/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-http.py
+++ b/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-http.py
@@ -1,0 +1,124 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+
+import os
+
+from dotenv import load_dotenv
+from loguru import logger
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import create_transport
+from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.services.nvidia.sagemaker.tts import NvidiaSageMakerHTTPTTSService
+from pipecat.services.nvidia.sagemaker.stt import NvidiaSageMakerWebsocketSTTService
+
+load_dotenv(override=True)
+
+# We use lambdas to defer transport parameter creation until the transport
+# type is selected at runtime.
+transport_params = {
+    "webrtc": lambda: TransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+}
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
+    logger.info(f"Starting bot")
+
+    stt = NvidiaSageMakerWebsocketSTTService(
+        endpoint_name=os.getenv("SAGEMAKER_ASR_ENDPOINT_NAME"),
+        region=os.getenv("AWS_REGION", "us-west-2"),
+    )
+
+    llm = OpenAILLMService(
+        api_key="not_needed",
+        base_url=os.getenv("NEMOTRON_LLM_BASE_URL"),
+        model="nemotron-3-super-120b",
+        system_instruction="You are a real-time AI voice assistant. Keep responses short and sharp. Use plain speech and quick sentences. Avoid any symbols, emojis or formatting. Show usefulness in as few words as possible. Keep you response simple, maximum of 40 words each.",
+        params=OpenAILLMService.InputParams(
+            temperature=0.0,
+            extra={
+                "extra_body": {
+                    "chat_template_kwargs": {
+                        "enable_thinking": False,
+                    }
+                }
+            },
+        ),
+    )
+
+    tts = NvidiaSageMakerHTTPTTSService(
+        endpoint_name=os.getenv("SAGEMAKER_MAGPIE_ENDPOINT_NAME"),
+        region=os.getenv("AWS_REGION", "us-west-2"),
+    )
+
+    context = LLMContext()
+    user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+        context,
+        user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer()),
+    )
+
+    pipeline = Pipeline(
+        [
+            transport.input(),  # Transport user input
+            stt,  # STT
+            user_aggregator,  # User responses
+            llm,  # LLM
+            tts,  # TTS
+            transport.output(),  # Transport bot output
+            assistant_aggregator,  # Assistant spoken responses
+        ]
+    )
+
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+        idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+    )
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        logger.info(f"Client connected")
+        # Kick off the conversation.
+        context.add_message({"role": "developer", "content": "Please introduce yourself to the user."})
+        await task.queue_frames([LLMRunFrame()])
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await task.cancel()
+
+    runner = PipelineRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.run(task)
+
+
+async def bot(runner_args: RunnerArguments):
+    """Main bot entry point compatible with Pipecat Cloud."""
+    transport = await create_transport(runner_args, transport_params)
+    await run_bot(transport, runner_args)
+
+
+if __name__ == "__main__":
+    from pipecat.runner.run import main
+
+    main()

--- a/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-ws.py
+++ b/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-ws.py
@@ -21,11 +21,11 @@ from pipecat.processors.aggregators.llm_response_universal import (
 )
 from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
+from pipecat.services.nvidia.sagemaker.stt import NvidiaSageMakerWebsocketSTTService
+from pipecat.services.nvidia.sagemaker.tts import NvidiaSageMakerWebsocketTTSService
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
-from pipecat.services.nvidia.sagemaker.stt import NvidiaSageMakerWebsocketSTTService
-from pipecat.services.nvidia.sagemaker.tts import NvidiaSageMakerWebsocketTTSService
 
 load_dotenv(override=True)
 

--- a/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-ws.py
+++ b/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-ws.py
@@ -21,8 +21,8 @@ from pipecat.processors.aggregators.llm_response_universal import (
 )
 from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
-from pipecat.services.nvidia.sagemaker.stt import NvidiaSageMakerWebsocketSTTService
-from pipecat.services.nvidia.sagemaker.tts import NvidiaSageMakerWebsocketTTSService
+from pipecat.services.nvidia.sagemaker.stt import NvidiaSageMakerSTTService
+from pipecat.services.nvidia.sagemaker.tts import NvidiaSageMakerTTSService
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
@@ -46,7 +46,7 @@ transport_params = {
 async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     logger.info(f"Starting bot")
 
-    stt = NvidiaSageMakerWebsocketSTTService(
+    stt = NvidiaSageMakerSTTService(
         endpoint_name=os.getenv("SAGEMAKER_ASR_ENDPOINT_NAME"),
         region=os.getenv("AWS_REGION", "us-west-2"),
     )
@@ -68,7 +68,7 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ),
     )
 
-    tts = NvidiaSageMakerWebsocketTTSService(
+    tts = NvidiaSageMakerTTSService(
         endpoint_name=os.getenv("SAGEMAKER_MAGPIE_ENDPOINT_NAME"),
         region=os.getenv("AWS_REGION", "us-west-2"),
     )

--- a/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-ws.py
+++ b/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-ws.py
@@ -21,9 +21,9 @@ from pipecat.processors.aggregators.llm_response_universal import (
 )
 from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
+from pipecat.services.aws.llm import AWSBedrockLLMService, AWSBedrockLLMSettings
 from pipecat.services.nvidia.sagemaker.stt import NvidiaSageMakerSTTService
 from pipecat.services.nvidia.sagemaker.tts import NvidiaSageMakerTTSService
-from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
 
@@ -51,20 +51,11 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         region=os.getenv("AWS_REGION", "us-west-2"),
     )
 
-    llm = OpenAILLMService(
-        api_key="not_needed",
-        base_url=os.getenv("NEMOTRON_LLM_BASE_URL"),
-        model="nemotron-3-super-120b",
-        system_instruction="You are a real-time AI voice assistant. Keep responses short and sharp. Use plain speech and quick sentences. Avoid any symbols, emojis or formatting. Show usefulness in as few words as possible. Keep you response simple, maximum of 40 words each.",
-        params=OpenAILLMService.InputParams(
-            temperature=0.0,
-            extra={
-                "extra_body": {
-                    "chat_template_kwargs": {
-                        "enable_thinking": False,
-                    }
-                }
-            },
+    llm = AWSBedrockLLMService(
+        aws_region=os.getenv("AWS_REGION"),
+        settings=AWSBedrockLLMSettings(
+            model="nvidia.nemotron-super-3-120b",
+            system_instruction="You are a real-time AI voice assistant. Keep responses short and sharp. Use plain speech and quick sentences. Avoid any symbols, emojis or formatting. Show usefulness in as few words as possible. Keep you response simple, maximum of 40 words each.",
         ),
     )
 

--- a/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-ws.py
+++ b/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-ws.py
@@ -1,0 +1,130 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+
+import os
+
+from dotenv import load_dotenv
+from loguru import logger
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import LLMRunFrame
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import create_transport
+from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.daily.transport import DailyParams
+from pipecat.services.nvidia.sagemaker.stt import NvidiaSageMakerWebsocketSTTService
+from pipecat.services.nvidia.sagemaker.tts import NvidiaSageMakerWebsocketTTSService
+
+load_dotenv(override=True)
+
+# We use lambdas to defer transport parameter creation until the transport
+# type is selected at runtime.
+transport_params = {
+    "daily": lambda: DailyParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "webrtc": lambda: TransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+}
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
+    logger.info(f"Starting bot")
+
+    stt = NvidiaSageMakerWebsocketSTTService(
+        endpoint_name=os.getenv("SAGEMAKER_ASR_ENDPOINT_NAME"),
+        region=os.getenv("AWS_REGION", "us-west-2"),
+    )
+
+    llm = OpenAILLMService(
+        api_key="not_needed",
+        base_url=os.getenv("NEMOTRON_LLM_BASE_URL"),
+        model="nemotron-3-super-120b",
+        system_instruction="You are a real-time AI voice assistant. Keep responses short and sharp. Use plain speech and quick sentences. Avoid any symbols, emojis or formatting. Show usefulness in as few words as possible. Keep you response simple, maximum of 40 words each.",
+        params=OpenAILLMService.InputParams(
+            temperature=0.0,
+            extra={
+                "extra_body": {
+                    "chat_template_kwargs": {
+                        "enable_thinking": False,
+                    }
+                }
+            },
+        ),
+    )
+
+    tts = NvidiaSageMakerWebsocketTTSService(
+        endpoint_name=os.getenv("SAGEMAKER_MAGPIE_ENDPOINT_NAME"),
+        region=os.getenv("AWS_REGION", "us-west-2"),
+    )
+
+    context = LLMContext()
+    user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+        context,
+        user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer()),
+    )
+
+    pipeline = Pipeline(
+        [
+            transport.input(),  # Transport user input
+            stt,  # STT
+            user_aggregator,  # User responses
+            llm,  # LLM
+            tts,  # TTS
+            transport.output(),  # Transport bot output
+            assistant_aggregator,  # Assistant spoken responses
+        ]
+    )
+
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+        idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+    )
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        logger.info(f"Client connected")
+        # Kick off the conversation.
+        context.add_message({"role": "developer", "content": "Please introduce yourself to the user."})
+        await task.queue_frames([LLMRunFrame()])
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info(f"Client disconnected")
+        await task.cancel()
+
+    runner = PipelineRunner(handle_sigint=runner_args.handle_sigint)
+
+    await runner.run(task)
+
+
+async def bot(runner_args: RunnerArguments):
+    """Main bot entry point compatible with Pipecat Cloud."""
+    transport = await create_transport(runner_args, transport_params)
+    await run_bot(transport, runner_args)
+
+
+if __name__ == "__main__":
+    logger.info(f"Starting bot {os.getenv("AWS_REGION", "us-west-2")}")
+    from pipecat.runner.run import main
+
+    main()

--- a/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-ws.py
+++ b/deployment/aws-sagemaker-nvidia/client/bot/pipecat-bot-ws.py
@@ -104,7 +104,9 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     async def on_client_connected(transport, client):
         logger.info(f"Client connected")
         # Kick off the conversation.
-        context.add_message({"role": "developer", "content": "Please introduce yourself to the user."})
+        context.add_message(
+            {"role": "developer", "content": "Please introduce yourself to the user."}
+        )
         await task.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_client_disconnected")
@@ -124,7 +126,7 @@ async def bot(runner_args: RunnerArguments):
 
 
 if __name__ == "__main__":
-    logger.info(f"Starting bot {os.getenv("AWS_REGION", "us-west-2")}")
+    logger.info(f"Starting bot {os.getenv('AWS_REGION', 'us-west-2')}")
     from pipecat.runner.run import main
 
     main()

--- a/deployment/aws-sagemaker-nvidia/client/env.example
+++ b/deployment/aws-sagemaker-nvidia/client/env.example
@@ -1,0 +1,22 @@
+# ─────────────────────────────────────────────
+# AWS — SageMaker runtime credentials
+# ─────────────────────────────────────────────
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_REGION=us-west-2
+
+# ─────────────────────────────────────────────
+# SageMaker endpoint names
+# ─────────────────────────────────────────────
+# Deployed Nemotron ASR endpoint (used by STT service)
+SAGEMAKER_ASR_ENDPOINT_NAME=nemotron-asr-endpoint
+
+# Deployed Magpie TTS endpoint (used by TTS service)
+SAGEMAKER_MAGPIE_ENDPOINT_NAME=magpie-tts-endpoint
+
+# ─────────────────────────────────────────────
+# LLM — Nemotron Super (Modal hosted)
+# ─────────────────────────────────────────────
+# Base URL for the Nemotron Super model hosted on Modal.
+# The bots use OpenAILLMService pointed at this endpoint (no API key required).
+NEMOTRON_LLM_BASE_URL=

--- a/deployment/aws-sagemaker-nvidia/client/pcc-deploy.toml
+++ b/deployment/aws-sagemaker-nvidia/client/pcc-deploy.toml
@@ -1,0 +1,6 @@
+agent_name = "nvidia-nim-bot"
+secret_set = "nvidia-nim-secrets"
+agent_profile = "agent-1x"
+
+[scaling]
+    min_agents = 1

--- a/deployment/aws-sagemaker-nvidia/client/pyproject.toml
+++ b/deployment/aws-sagemaker-nvidia/client/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "nvidia-sgmaker-example"
+version = "0.1.0"
+description = "Quickstart example for using NVIDIA models with AWS Sagemaker"
+requires-python = ">=3.12"
+dependencies = [
+    "pipecat-ai[nvidia,runner,silero,webrtc,daily,sagemaker,aws]>=0.0.105",
+    "pipecat-ai-small-webrtc-prebuilt>=2.3.0",
+    "pipecat-ai-cli",
+]
+
+[dependency-groups]
+dev = [
+    "ruff~=0.12.1",
+]
+
+[tool.ruff]
+line-length = 100
+[tool.ruff.lint]
+select = ["I"]

--- a/deployment/aws-sagemaker-nvidia/client/test/test_asr_ws.py
+++ b/deployment/aws-sagemaker-nvidia/client/test/test_asr_ws.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+SageMaker bidirectional-stream test client for the Nemotron ASR wrapper.
+
+Uses SageMaker's HTTP/2 bidi stream API (InvokeEndpointWithBidirectionalStream)
+to communicate with the wrapper's /invocations-bidirectional-stream endpoint,
+which transparently proxies to NIM's realtime WebSocket.
+
+The client streams audio as base64-encoded PCM16 chunks via
+input_audio_buffer.append events and collects transcription results from
+conversation.item.input_audio_transcription.completed events.
+
+Falls back to ./tmp/magpie-test.pcm (Magpie TTS output) if no audio is provided.
+
+Usage:
+    python client/test/test_asr_ws.py
+    python client/test/test_asr_ws.py --audio /path/to/audio.wav
+    python client/test/test_asr_ws.py --audio /path/to/audio.pcm --language en-US
+"""
+
+import argparse
+import asyncio
+import base64
+import io
+import json
+import os
+import wave
+from pathlib import Path
+
+from aws_sdk_sagemaker_runtime_http2.client import SageMakerRuntimeHTTP2Client
+from aws_sdk_sagemaker_runtime_http2.config import Config, HTTPAuthSchemeResolver
+from aws_sdk_sagemaker_runtime_http2.models import (
+    InvokeEndpointWithBidirectionalStreamInput,
+    RequestPayloadPart,
+    RequestStreamEventPayloadPart,
+)
+from smithy_aws_core.auth.sigv4 import SigV4AuthScheme
+from smithy_aws_core.identity import EnvironmentCredentialsResolver
+
+# ── .env loader ───────────────────────────────────────────────────────────────
+
+
+def _load_env(path: Path) -> None:
+    if not path.exists():
+        return
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip())
+
+
+# ── Audio helpers ─────────────────────────────────────────────────────────────
+
+
+def _pcm_to_wav(pcm_bytes: bytes, sample_rate: int) -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm_bytes)
+    return buf.getvalue()
+
+
+def _resolve_pcm(audio_arg: str | None, pcm_sample_rate: int) -> tuple[bytes, int, str]:
+    """
+    Resolve audio input to raw PCM16 bytes + sample rate.
+
+    Priority:
+      1. --audio argument (.wav read and extracted, .pcm used as-is)
+      2. ./tmp/magpie-test.pcm (Magpie TTS output)
+      3. Error
+
+    Returns (pcm_bytes, sample_rate, description).
+    """
+    if audio_arg:
+        path = Path(audio_arg)
+        if not path.exists():
+            raise SystemExit(f"ERROR: Audio file not found: {audio_arg}")
+        if path.suffix.lower() == ".wav":
+            with wave.open(str(path), "rb") as wf:
+                sr = wf.getframerate()
+                pcm = wf.readframes(wf.getnframes())
+            return pcm, sr, str(path)
+        data = path.read_bytes()
+        return data, pcm_sample_rate, f"{path}  (PCM16, {pcm_sample_rate} Hz)"
+
+    fallback = Path("./tmp/magpie-test.pcm")
+    if fallback.exists():
+        magpie_sr = int(os.environ.get("MAGPIE_SAMPLE_RATE_HZ", "22050"))
+        return fallback.read_bytes(), magpie_sr, f"./tmp/magpie-test.pcm  ({magpie_sr} Hz)"
+
+    raise SystemExit(
+        "ERROR: No audio file provided and ./tmp/magpie-test.pcm not found.\n"
+        "  Provide an audio file:  --audio /path/to/audio.wav"
+    )
+
+
+# ── Bidi stream client ────────────────────────────────────────────────────────
+
+# Audio is sent in 40 ms chunks.
+CHUNK_MS = 40
+
+
+async def run(
+    endpoint: str,
+    region: str,
+    language: str,
+    pcm_bytes: bytes,
+    sample_rate: int,
+) -> None:
+    bidi_endpoint = f"https://runtime.sagemaker.{region}.amazonaws.com:8443"
+    print(f"→ Connecting to SageMaker bidi stream ({bidi_endpoint}) ...")
+
+    config = Config(
+        endpoint_uri=bidi_endpoint,
+        region=region,
+        aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
+        auth_scheme_resolver=HTTPAuthSchemeResolver(),
+        auth_schemes={"aws.auth#sigv4": SigV4AuthScheme(service="sagemaker")},
+    )
+    client = SageMakerRuntimeHTTP2Client(config=config)
+
+    stream_input = InvokeEndpointWithBidirectionalStreamInput(endpoint_name=endpoint)
+    stream = await client.invoke_endpoint_with_bidirectional_stream(stream_input)
+
+    print("→ Waiting for stream ...")
+    output_future, output_stream = await stream.await_output()
+
+    async def send_json(data: dict) -> None:
+        payload = RequestPayloadPart(
+            bytes_=json.dumps(data).encode("utf-8"),
+            data_type="UTF8",
+        )
+        await stream.input_stream.send(RequestStreamEventPayloadPart(value=payload))
+
+    # ── 1. Configure transcription session ────────────────────────────────────
+    # "model": "nemotron-asr-streaming" selects the Nemotron ASR Streaming model on NIM.
+    await send_json(
+        {
+            "type": "transcription_session.update",
+            "session": {
+                "input_audio_format": "pcm16",
+                "input_audio_params": {
+                    "sample_rate_hz": sample_rate,
+                    "num_channels": 1,
+                },
+                "input_audio_transcription": {
+                    "language": language,
+                    "model": "cache-aware-parakeet-rnnt-en-US-asr-streaming-sortformer",
+                },
+            },
+        }
+    )
+
+    # ── 2. Stream audio in chunks ─────────────────────────────────────────────
+    # Commit after every chunk (matches NVIDIA reference client pattern).
+    bytes_per_sample = 2  # PCM16
+    chunk_samples = int(sample_rate * CHUNK_MS / 1000)
+    chunk_bytes = chunk_samples * bytes_per_sample
+
+    print(f"→ Sending audio ({len(pcm_bytes):,} bytes, {CHUNK_MS} ms chunks) ...")
+    for offset in range(0, len(pcm_bytes), chunk_bytes):
+        chunk = pcm_bytes[offset : offset + chunk_bytes]
+        await send_json(
+            {"type": "input_audio_buffer.append", "audio": base64.b64encode(chunk).decode()}
+        )
+        await send_json({"type": "input_audio_buffer.commit"})
+
+    await send_json({"type": "input_audio_buffer.done"})
+
+    # ── 3. Collect transcription events ───────────────────────────────────────
+    print("→ Waiting for transcript ...")
+    transcript = ""
+
+    while True:
+        try:
+            event = await asyncio.wait_for(output_stream.receive(), timeout=10.0)
+        except asyncio.TimeoutError:
+            print("WARNING: No response for 10 seconds — closing session.")
+            break
+        if event is None:
+            break
+
+        raw = getattr(event, "value", None)
+        if raw is None:
+            continue
+        data = getattr(raw, "bytes_", None) or getattr(raw, "bytes", None)
+        if not data:
+            continue
+
+        try:
+            msg = json.loads(data.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+
+        event_type = msg.get("type", "")
+
+        if event_type == "conversation.item.input_audio_transcription.delta":
+            print(f"  delta: {msg.get('delta', '')}", flush=True)
+
+        elif event_type == "conversation.item.input_audio_transcription.completed":
+            transcript = msg.get("transcript", "")
+            break
+
+        elif event_type == "conversation.item.input_audio_transcription.failed":
+            print(f"\nERROR: Transcription failed: {msg}")
+            raise SystemExit(1)
+
+        elif event_type == "error":
+            raise RuntimeError(f"NIM error: {msg}")
+
+    await stream.input_stream.close()
+
+    if not transcript:
+        print()
+        print("ERROR: No transcript received.")
+        raise SystemExit(1)
+
+    print()
+    print(f"✓ Transcript: {transcript}")
+    print()
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    _load_env(Path(__file__).parent.parent.parent / ".env")
+
+    parser = argparse.ArgumentParser(
+        description="SageMaker bidi-stream test client for Nemotron ASR",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--audio",
+        default=None,
+        help="Path to audio file (.wav or raw PCM16). Falls back to ./tmp/magpie-test.pcm if omitted.",
+    )
+    parser.add_argument(
+        "--language",
+        default=os.environ.get("NEMOTRON_ASR_LANGUAGE_CODE", "en-US"),
+        help="BCP-47 language code",
+    )
+    parser.add_argument(
+        "--sample-rate",
+        type=int,
+        default=int(os.environ.get("NEMOTRON_ASR_SAMPLE_RATE_HZ", "16000")),
+        help="Sample rate in Hz — only used when input is raw PCM (not WAV)",
+    )
+    parser.add_argument(
+        "--endpoint",
+        default=os.environ.get("SAGEMAKER_ASR_ENDPOINT_NAME", ""),
+        help="SageMaker endpoint name (overrides SAGEMAKER_ASR_ENDPOINT_NAME in .env)",
+    )
+    args = parser.parse_args()
+
+    if not args.endpoint:
+        parser.error(
+            "Endpoint name required. Set SAGEMAKER_ASR_ENDPOINT_NAME in .env or pass --endpoint <name>."
+        )
+
+    region = os.environ.get("AWS_REGION", "us-west-2")
+    pcm_bytes, sample_rate, audio_desc = _resolve_pcm(args.audio, args.sample_rate)
+
+    print()
+    print("━" * 60)
+    print(" Testing SageMaker Endpoint  [nemotron-asr — bidi-stream]")
+    print()
+    print(f" Endpoint   : {args.endpoint}")
+    print(f" Region     : {region}")
+    print(f" Language   : {args.language}")
+    print(f" Audio      : {audio_desc}")
+    print("━" * 60)
+    print()
+
+    asyncio.run(run(args.endpoint, region, args.language, pcm_bytes, sample_rate))
+
+
+if __name__ == "__main__":
+    main()

--- a/deployment/aws-sagemaker-nvidia/client/test/test_magpie_http.py
+++ b/deployment/aws-sagemaker-nvidia/client/test/test_magpie_http.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Test client for the Magpie TTS SageMaker endpoint.
+
+Sends a synthesis request and saves the response as a WAV file.
+Requires only aioboto3 (no ffmpeg — WAV conversion uses stdlib wave).
+
+Usage:
+    python client/test_http.py
+    python client/test_http.py --text "Custom text to synthesize"
+    python client/test_http.py --text "Hello" --output ./tmp/hello.wav
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import wave
+from pathlib import Path
+
+import aioboto3
+
+# ── .env loader ───────────────────────────────────────────────────────────────
+
+
+def _load_env(path: Path) -> None:
+    """Load key=value pairs from a .env file into os.environ (no-op if missing)."""
+    if not path.exists():
+        return
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip())
+
+
+# ── Audio helpers ─────────────────────────────────────────────────────────────
+
+
+def _save_wav(pcm_data: bytes, sample_rate: int, output: Path) -> None:
+    """Wrap raw signed 16-bit mono PCM in a WAV container."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(output), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)  # 16-bit = 2 bytes per sample
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm_data)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
+async def run(args: argparse.Namespace, region: str) -> None:
+    body = json.dumps(
+        {
+            "text": args.text,
+            "voice_name": args.voice,
+            "language_code": args.language,
+            "sample_rate_hz": args.sample_rate,
+        }
+    )
+
+    session = aioboto3.Session(
+        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+        region_name=region,
+    )
+
+    print("→ Invoking endpoint ...")
+    try:
+        async with session.client("sagemaker-runtime") as client:
+            response = await client.invoke_endpoint(
+                EndpointName=args.endpoint,
+                ContentType="application/json",
+                Accept="application/octet-stream",
+                Body=body,
+            )
+            pcm_data = await response["Body"].read()
+    except Exception as exc:
+        print()
+        print(f"ERROR: {exc}")
+        print("  Check that the endpoint is InService: ./scripts/list_endpoints.sh")
+        raise SystemExit(1)
+
+    if not pcm_data:
+        print()
+        print("ERROR: Endpoint returned an empty response.")
+        print("  Check the endpoint logs: ./scripts/logs_endpoint.sh")
+        raise SystemExit(1)
+
+    print("→ Saving WAV ...")
+    _save_wav(pcm_data, args.sample_rate, args.output)
+
+    print()
+    print(f"✓ Audio saved to {args.output}")
+    print()
+    print("  To play:")
+    print(f"    afplay {args.output}        # macOS")
+    print(f"    ffplay {args.output}        # cross-platform")
+    print()
+
+
+def main() -> None:
+    _load_env(Path(__file__).parent.parent.parent / ".env")
+
+    parser = argparse.ArgumentParser(
+        description="Test the Magpie TTS SageMaker endpoint",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--text",
+        default="Hello! This is a test of the NVIDIA Magpie TTS endpoint deployed on AWS SageMaker.",
+    )
+    parser.add_argument(
+        "--voice",
+        default=os.environ.get("MAGPIE_VOICE", "Magpie-Multilingual.EN-US.Aria"),
+    )
+    parser.add_argument(
+        "--language",
+        default=os.environ.get("MAGPIE_LANGUAGE_CODE", "en-US"),
+    )
+    parser.add_argument(
+        "--sample-rate",
+        type=int,
+        default=int(os.environ.get("MAGPIE_SAMPLE_RATE_HZ", "24000")),
+    )
+    parser.add_argument(
+        "--endpoint",
+        default=os.environ.get("SAGEMAKER_MAGPIE_ENDPOINT_NAME", ""),
+        help="SageMaker endpoint name (overrides SAGEMAKER_MAGPIE_ENDPOINT_NAME in .env)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("./tmp/magpie-test.wav"),
+    )
+    args = parser.parse_args()
+
+    if not args.endpoint:
+        parser.error(
+            "Endpoint name required. Set SAGEMAKER_MAGPIE_ENDPOINT_NAME in .env or pass --endpoint <name>."
+        )
+
+    region = os.environ.get("AWS_REGION", "us-west-2")
+
+    print()
+    print("━" * 60)
+    print(" Testing SageMaker Endpoint")
+    print()
+    print(f" Endpoint   : {args.endpoint}")
+    print(f" Region     : {region}")
+    print(f" Voice      : {args.voice}")
+    print(f" Language   : {args.language}")
+    print(f" Sample rate: {args.sample_rate} Hz")
+    print(f" Text       : {args.text}")
+    print(f" Output     : {args.output}")
+    print("━" * 60)
+    print()
+
+    asyncio.run(run(args, region))
+
+
+if __name__ == "__main__":
+    main()

--- a/deployment/aws-sagemaker-nvidia/client/test/test_magpie_ws.py
+++ b/deployment/aws-sagemaker-nvidia/client/test/test_magpie_ws.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""
+SageMaker bidirectional-stream test client for the Magpie TTS wrapper.
+
+Uses SageMaker's HTTP/2 bidi stream API (InvokeEndpointWithBidirectionalStream)
+to communicate with the wrapper's /invocations-bidirectional-stream endpoint,
+which transparently proxies to NIM's realtime WebSocket.
+
+The wrapper forwards NIM's JSON protocol verbatim, so this client sends
+NIM events as UTF-8 text and receives NIM's JSON responses, decoding the
+base64 audio from conversation.item.speech.data events into a WAV file.
+
+Usage:
+    python client/test_ws.py
+    python client/test_ws.py --text "Custom text to synthesize"
+    python client/test_ws.py --text "Hello" --output ./tmp/bidi-test.wav
+"""
+
+import argparse
+import asyncio
+import base64
+import json
+import os
+import wave
+from pathlib import Path
+
+from aws_sdk_sagemaker_runtime_http2.client import SageMakerRuntimeHTTP2Client
+from aws_sdk_sagemaker_runtime_http2.config import Config, HTTPAuthSchemeResolver
+from aws_sdk_sagemaker_runtime_http2.models import (
+    InvokeEndpointWithBidirectionalStreamInput,
+    RequestPayloadPart,
+    RequestStreamEventPayloadPart,
+)
+from smithy_aws_core.auth.sigv4 import SigV4AuthScheme
+from smithy_aws_core.identity import EnvironmentCredentialsResolver
+
+# ── .env loader ───────────────────────────────────────────────────────────────
+
+
+def _load_env(path: Path) -> None:
+    if not path.exists():
+        return
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip())
+
+
+# ── Audio helpers ─────────────────────────────────────────────────────────────
+
+
+def _save_wav(pcm_data: bytes, sample_rate: int, output: Path) -> None:
+    """Wrap raw signed 16-bit mono PCM in a WAV container."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(output), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)  # 16-bit = 2 bytes per sample
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm_data)
+
+
+# ── Bidi stream client ────────────────────────────────────────────────────────
+
+
+async def run(
+    endpoint: str,
+    region: str,
+    text: str,
+    voice: str,
+    language: str,
+    sample_rate: int,
+    output: Path,
+) -> None:
+    bidi_endpoint = f"https://runtime.sagemaker.{region}.amazonaws.com:8443"
+    print(f"→ Connecting to SageMaker bidi stream ({bidi_endpoint}) ...")
+
+    config = Config(
+        endpoint_uri=bidi_endpoint,
+        region=region,
+        aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
+        auth_scheme_resolver=HTTPAuthSchemeResolver(),
+        auth_schemes={"aws.auth#sigv4": SigV4AuthScheme(service="sagemaker")},
+    )
+    client = SageMakerRuntimeHTTP2Client(config=config)
+
+    stream_input = InvokeEndpointWithBidirectionalStreamInput(
+        endpoint_name=endpoint,
+    )
+
+    print("Will invoke endpoint:", endpoint)
+
+    stream = await client.invoke_endpoint_with_bidirectional_stream(stream_input)
+
+    print("Waiting for stream be available...")
+    output_future, output_stream = await stream.await_output()
+
+    # ── Helper: send a NIM JSON event ─────────────────────────────────────────
+    async def send_json(data: dict) -> None:
+        payload = RequestPayloadPart(
+            bytes_=json.dumps(data).encode("utf-8"),
+            data_type="UTF8",
+        )
+        await stream.input_stream.send(RequestStreamEventPayloadPart(value=payload))
+
+    # ── 1. Configure synthesis session ────────────────────────────────────────
+    await send_json(
+        {
+            "type": "synthesize_session.update",
+            "session": {
+                "input_text_synthesis": {
+                    "voice_name": voice,
+                    "language_code": language,
+                },
+                "output_audio_params": {
+                    "sample_rate_hz": sample_rate,
+                },
+            },
+        }
+    )
+
+    print("Sending audio ...")
+
+    # ── 2. Send text ──────────────────────────────────────────────────────────
+    await send_json({"type": "input_text.append", "text": text})
+    await send_json({"type": "input_text.commit"})
+    await send_json({"type": "input_text.done"})
+
+    print("→ Waiting for audio ...")
+
+    # ── 3. Collect audio from NIM JSON events ──────────────────────────────────
+    audio_chunks: list[bytes] = []
+
+    while True:
+        try:
+            event = await asyncio.wait_for(output_stream.receive(), timeout=5.0)
+        except asyncio.TimeoutError:
+            print("WARNING: No audio received for 5 seconds — closing session.")
+            break
+        if event is None:
+            break
+
+        # ResponseStreamEvent.payload_part.bytes_ contains the raw bytes that
+        # the wrapper forwarded from NIM (UTF-8 encoded JSON text).
+        raw = getattr(event, "value", None)
+        if raw is None:
+            continue
+
+        data = getattr(raw, "bytes_", None) or getattr(raw, "bytes", None)
+        if not data:
+            continue
+
+        try:
+            msg = json.loads(data.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            # Binary frame (shouldn't happen with transparent proxy, but handle it)
+            audio_chunks.append(data)
+            continue
+
+        event_type = msg.get("type", "")
+
+        if event_type == "conversation.item.speech.data":
+            chunk_b64 = msg.get("audio", "")
+            if chunk_b64:
+                audio_chunks.append(base64.b64decode(chunk_b64))
+            if msg.get("is_last_chunk"):
+                break
+
+        elif event_type == "conversation.item.speech.completed":
+            break
+
+        elif event_type == "error":
+            raise RuntimeError(f"NIM error: {msg}")
+
+        # Other events (session.created, etc.) are silently ignored.
+
+    # ── 4. Close the session ──────────────────────────────────────────────────
+    # The wrapper intercepts this message and closes the NIM WebSocket cleanly.
+    await send_json({"type": "session.end"})
+    await stream.input_stream.close()
+
+    if not audio_chunks:
+        print()
+        print("ERROR: No audio received.")
+        raise SystemExit(1)
+
+    pcm_data = b"".join(audio_chunks)
+    print(f"→ Received {len(pcm_data):,} bytes of PCM — saving WAV ...")
+    _save_wav(pcm_data, sample_rate, output)
+
+    print()
+    print(f"✓ Audio saved to {output}")
+    print()
+    print("  To play:")
+    print(f"    afplay {output}        # macOS")
+    print(f"    ffplay {output}        # cross-platform")
+    print()
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    _load_env(Path(__file__).parent.parent.parent / ".env")
+
+    parser = argparse.ArgumentParser(
+        description="SageMaker bidi-stream test client for Magpie TTS",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--endpoint",
+        default=os.environ.get("SAGEMAKER_MAGPIE_ENDPOINT_NAME", ""),
+        help="SageMaker endpoint name (overrides SAGEMAKER_MAGPIE_ENDPOINT_NAME in .env)",
+    )
+    parser.add_argument(
+        "--region",
+        default=os.environ.get("AWS_REGION", "us-west-2"),
+    )
+    parser.add_argument(
+        "--text",
+        default="Hello! This is a bidirectional stream test of the NVIDIA Magpie TTS endpoint.",
+    )
+    parser.add_argument(
+        "--voice",
+        default=os.environ.get("MAGPIE_VOICE", "Magpie-Multilingual.EN-US.Aria"),
+    )
+    parser.add_argument(
+        "--language",
+        default=os.environ.get("MAGPIE_LANGUAGE_CODE", "en-US"),
+    )
+    parser.add_argument(
+        "--sample-rate",
+        type=int,
+        default=int(os.environ.get("MAGPIE_SAMPLE_RATE_HZ", "22050")),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("./tmp/magpie-bidi-test.wav"),
+    )
+    args = parser.parse_args()
+
+    if not args.endpoint:
+        parser.error(
+            "Endpoint name required. Set SAGEMAKER_MAGPIE_ENDPOINT_NAME in .env or pass --endpoint <name>."
+        )
+
+    print()
+    print("━" * 60)
+    print(" Testing Magpie TTS — SageMaker Bidi Stream")
+    print()
+    print(f" Endpoint   : {args.endpoint}")
+    print(f" Region     : {args.region}")
+    print(f" Voice      : {args.voice}")
+    print(f" Language   : {args.language}")
+    print(f" Sample rate: {args.sample_rate} Hz")
+    print(f" Text       : {args.text}")
+    print(f" Output     : {args.output}")
+    print("━" * 60)
+    print()
+
+    asyncio.run(
+        run(
+            endpoint=args.endpoint,
+            region=args.region,
+            text=args.text,
+            voice=args.voice,
+            language=args.language,
+            sample_rate=args.sample_rate,
+            output=args.output,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/deployment/aws-sagemaker-nvidia/env.example
+++ b/deployment/aws-sagemaker-nvidia/env.example
@@ -1,0 +1,145 @@
+# ─────────────────────────────────────────────
+# NVIDIA NGC
+# ─────────────────────────────────────────────
+# Your NGC API key — used to pull NIM containers from nvcr.io and to
+# authenticate the NIM container at runtime so it can download model weights.
+# Get one at: https://build.nvidia.com
+NGC_API_KEY=...
+
+# ─────────────────────────────────────────────
+# AWS — Deployer credentials
+# ─────────────────────────────────────────────
+# Credentials for the IAM user created by scripts/create_iam.sh
+# This user has the minimal permissions to push to ECR and deploy on SageMaker
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_REGION=us-west-2
+
+# ─────────────────────────────────────────────
+# AWS — IAM
+# ─────────────────────────────────────────────
+# ARN of the SageMaker execution role — printed by scripts/create_iam.sh
+# Example: arn:aws:iam::<ACCOUNT_ID>:role/magpie-sagemaker-execution-role
+SAGEMAKER_EXECUTION_ROLE_ARN=
+
+# ─────────────────────────────────────────────
+# NIM container — shared runtime settings
+# ─────────────────────────────────────────────
+# NIM's internal HTTP and gRPC ports (same defaults for both NIMs).
+# Do NOT set NIM_HTTP_API_PORT=8080 — that would conflict with the wrapper.
+NIM_HTTP_API_PORT=9000
+NIM_GRPC_API_PORT=50051
+
+# (Optional) Restrict PyTorch JIT compilation to the GPU architecture of your instance.
+# Speeds up NIM startup by avoiding unnecessary multi-arch compilation.
+# Values by instance family:
+#   ml.g6.*  (L4,   SM 8.9) → 8.9
+#   ml.g5.*  (A10G, SM 8.6) → 8.6
+# Leave empty to let PyTorch auto-detect (slower startup, safe for any GPU).
+TORCH_CUDA_ARCH_LIST=8.9
+
+# How long (seconds) SageMaker waits for the container to pass health checks
+# before declaring deployment failed. NIM downloads model weights at startup
+# and can take up to 60 minutes. Max allowed by SageMaker: 3600s.
+SAGEMAKER_CONTAINER_STARTUP_TIMEOUT=3600
+
+# ═════════════════════════════════════════════
+# MAGPIE TTS
+# ═════════════════════════════════════════════
+
+# ─────────────────────────────────────────────
+# Magpie — Docker / ECR
+# ─────────────────────────────────────────────
+# Magpie NIM image tag to pull.
+# See all available tags:
+# https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/magpie-tts-multilingual/tags
+MAGPIE_IMAGE_TAG=latest
+
+# ECR repository name for the Magpie SageMaker wrapper image.
+ECR_MAGPIE_WRAPPER_REPO_NAME=magpie-tts-sagemaker
+
+# Full ECR URI of the Magpie WRAPPER image — printed by scripts/push_to_ecr.sh magpie
+# Example: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/magpie-tts-sagemaker:latest
+ECR_MAGPIE_IMAGE_URI=
+
+# ─────────────────────────────────────────────
+# Magpie — SageMaker Model & Endpoint
+# ─────────────────────────────────────────────
+SAGEMAKER_MAGPIE_MODEL_NAME=magpie-tts-multilingual
+SAGEMAKER_MAGPIE_ENDPOINT_CONFIG_NAME=magpie-tts-config
+SAGEMAKER_MAGPIE_ENDPOINT_NAME=magpie-tts-endpoint
+
+# GPU instance type for the Magpie endpoint.
+# Options (see DEPLOYMENT.md for full comparison):
+#   ml.g5.2xlarge  — 1x A10G 24GB  (recommended starting point)
+#   ml.g5.4xlarge  — 1x A10G 24GB  (more CPU/RAM for concurrency)
+#   ml.g5.12xlarge — 4x A10G 96GB  (high-throughput production)
+#   ml.g6.2xlarge  — 1x L4  24GB   (newer, cost-efficient)
+SAGEMAKER_MAGPIE_INSTANCE_TYPE=ml.g6.2xlarge
+SAGEMAKER_MAGPIE_INSTANCE_COUNT=1
+
+# ─────────────────────────────────────────────
+# Magpie — Voice settings  (used by client/test/test_magpie_*.py)
+# ─────────────────────────────────────────────
+MAGPIE_VOICE=Magpie-Multilingual.EN-US.Aria
+MAGPIE_LANGUAGE_CODE=en-US
+MAGPIE_SAMPLE_RATE_HZ=22050
+
+# ═════════════════════════════════════════════
+# NEMOTRON ASR STREAMING
+# ═════════════════════════════════════════════
+
+# ─────────────────────────────────────────────
+# Nemotron ASR — Docker / ECR
+# ─────────────────────────────────────────────
+# Nemotron ASR NIM image tag to pull.
+# See all available tags:
+# https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/nemotron-asr-streaming/tags
+NEMOTRON_ASR_IMAGE_TAG=latest
+
+# ECR repository name for the Nemotron ASR SageMaker wrapper image.
+ECR_ASR_WRAPPER_REPO_NAME=nemotron-asr-sagemaker
+
+# Full ECR URI of the Nemotron ASR WRAPPER image — printed by scripts/push_to_ecr.sh nemotron-asr
+# Example: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/nemotron-asr-sagemaker:latest
+ECR_ASR_IMAGE_URI=
+
+# ─────────────────────────────────────────────
+# Nemotron ASR — SageMaker Model & Endpoint
+# ─────────────────────────────────────────────
+SAGEMAKER_ASR_MODEL_NAME=nemotron-asr-streaming
+SAGEMAKER_ASR_ENDPOINT_CONFIG_NAME=nemotron-asr-config
+SAGEMAKER_ASR_ENDPOINT_NAME=nemotron-asr-endpoint
+
+# GPU instance type for the Nemotron ASR endpoint.
+# Options:
+#   ml.g5.2xlarge  — 1x A10G 24GB  (recommended starting point)
+#   ml.g5.4xlarge  — 1x A10G 24GB  (more CPU/RAM for concurrency)
+#   ml.g5.12xlarge — 4x A10G 96GB  (high-throughput production)
+#   ml.g6.2xlarge  — 1x L4  24GB   (newer, cost-efficient)
+SAGEMAKER_ASR_INSTANCE_TYPE=ml.g6.2xlarge
+SAGEMAKER_ASR_INSTANCE_COUNT=1
+
+# ─────────────────────────────────────────────
+# Nemotron ASR — settings  (used by client/test/test_asr_*.py)
+# ─────────────────────────────────────────────
+NEMOTRON_ASR_LANGUAGE_CODE=en-US
+NEMOTRON_ASR_SAMPLE_RATE_HZ=16000
+
+# ═════════════════════════════════════════════
+# CLIENT / PIPECAT BOT
+# ═════════════════════════════════════════════
+
+# ─────────────────────────────────────────────
+# NVIDIA API key  (NvidiaSTTService — hosted ASR)
+# ─────────────────────────────────────────────
+# Used by client/pipecat-bot-*.py when pointing at NVIDIA's hosted API.
+# Get one at: https://build.nvidia.com
+NVIDIA_API_KEY=
+
+# ─────────────────────────────────────────────
+# LLM — Nemotron Super (Modal hosted)
+# ─────────────────────────────────────────────
+# Base URL for the Nemotron Super model hosted on Modal.
+# The bots use OpenAILLMService pointed at this endpoint (no API key required).
+NEMOTRON_LLM_BASE_URL=

--- a/deployment/aws-sagemaker-nvidia/env.example
+++ b/deployment/aws-sagemaker-nvidia/env.example
@@ -71,11 +71,9 @@ SAGEMAKER_MAGPIE_ENDPOINT_NAME=magpie-tts-endpoint
 
 # GPU instance type for the Magpie endpoint.
 # Options (see DEPLOYMENT.md for full comparison):
-#   ml.g5.2xlarge  — 1x A10G 24GB  (recommended starting point)
-#   ml.g5.4xlarge  — 1x A10G 24GB  (more CPU/RAM for concurrency)
-#   ml.g5.12xlarge — 4x A10G 96GB  (high-throughput production)
-#   ml.g6.2xlarge  — 1x L4  24GB   (newer, cost-efficient)
-SAGEMAKER_MAGPIE_INSTANCE_TYPE=ml.g6.2xlarge
+# See all available instance types, drivers and GPU versions supported here:
+# https://docs.aws.amazon.com/sagemaker/latest/dg/inference-gpu-drivers.html?utm_source=chatgpt.com#inference-gpu-drivers-versions
+SAGEMAKER_MAGPIE_INSTANCE_TYPE=ml.g7e.2xlarge
 SAGEMAKER_MAGPIE_INSTANCE_COUNT=1
 
 # ─────────────────────────────────────────────

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/README.md
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/README.md
@@ -1,0 +1,47 @@
+# SageMaker Wrapper
+
+NVIDIA NIM containers expose their own HTTP/gRPC APIs. AWS SageMaker, however, requires every inference container to implement a **specific interface** before it can be deployed as an endpoint. This directory contains the wrapper layer that bridges the two.
+
+---
+
+## Why a wrapper is needed
+
+SageMaker makes two hard requirements of any inference container:
+
+| Requirement | What SageMaker does |
+|---|---|
+| `GET /ping` on port **8080** must return `200` when the model is ready | Used for health checks — SageMaker won't mark the endpoint `InService` until this passes |
+| `POST /invocations` on port **8080** handles inference requests | All client calls go through this endpoint |
+
+NVIDIA NIM containers don't expose either of these. They listen on port **9000** and use their own API paths.
+
+The wrapper solves this by running **alongside NIM inside the same container** as a lightweight FastAPI application on port 8080. It translates SageMaker's expected interface into the NIM's actual API.
+
+For real-time streaming use cases, SageMaker also supports a bidirectional WebSocket path (`WS /invocations-bidirectional-stream`), enabled via the container label `com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true`. The wrapper proxies this transparently to the NIM's WebSocket endpoint.
+
+---
+
+## How it runs inside the container
+
+`entrypoint.sh` is the container's `ENTRYPOINT`. It:
+
+1. Starts the NIM server in the background using the original NIM entrypoint (auto-detected at build time via `docker inspect` and baked in as `NIM_START_CMD`).
+2. Starts `uvicorn` (FastAPI wrapper) in the background on port 8080.
+3. Supervises both processes — if either one exits, it kills the other and exits with the same code.
+
+NIM can take up to 60 minutes to download model weights on first start. During that time, `/ping` returns `503`, which is expected — SageMaker keeps waiting (up to the configured `SAGEMAKER_CONTAINER_STARTUP_TIMEOUT`).
+
+---
+
+## NIM-specific wrappers
+
+| NIM | Wrapper | Description |
+|---|---|---|
+| Magpie TTS | [magpie/](magpie/README.md) | Text-to-speech — streams raw PCM audio |
+| Nemotron ASR Streaming | [nemotron-asr/](nemotron-asr/README.md) | Speech-to-text — returns JSON transcript |
+
+---
+
+## Building and deploying
+
+The wrapper is built, pushed, and deployed entirely through the scripts in `scripts/`. See [DEPLOYMENT.md](../DEPLOYMENT.md) for the full walkthrough.

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/Dockerfile
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/Dockerfile
@@ -1,0 +1,52 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Magpie TTS SageMaker Wrapper
+#
+# Extends the NVIDIA Magpie TTS NIM image with a FastAPI layer that translates
+# SageMaker's expected interface into NIM's actual API:
+#
+#   GET  /ping                              → NIM GET  /v1/health/ready        (HTTP :9000)
+#   POST /invocations                       → NIM POST /v1/audio/synthesize_online (HTTP :9000, streaming)
+#   WS   /invocations-bidirectional-stream  → NIM WS   /v1/realtime?intent=synthesize (:9000)
+#
+# The NIM server runs internally on port 9000 (its default).
+# The FastAPI wrapper runs on port 8080, which SageMaker expects.
+#
+# Build with:
+#   ./scripts/build_wrapper.sh
+# ─────────────────────────────────────────────────────────────────────────────
+
+# NIM_IMAGE is the local image pulled by pull_nim.sh.
+# Docker uses the local cache — it does not re-pull from NVIDIA's registry.
+ARG NIM_IMAGE=nvcr.io/nim/nvidia/magpie-tts-multilingual:latest
+FROM ${NIM_IMAGE}
+
+# NIM's original entrypoint + cmd — detected by build_wrapper.sh via docker inspect
+# and baked in here so entrypoint.sh knows how to start NIM without guessing.
+ARG NIM_START_CMD=""
+ENV NIM_START_CMD=${NIM_START_CMD}
+
+# ── uv (fast Python package manager — no apt-get needed) ─────────────────────
+# Copy the uv binary from its official image. Runs as root so we can write to
+# /opt/wrapper and /usr/local/bin.
+USER root
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# ── FastAPI wrapper dependencies ──────────────────────────────────────────────
+WORKDIR /opt/wrapper
+COPY sagemaker-wrapper/magpie/app/pyproject.toml /opt/wrapper/pyproject.toml
+RUN uv sync --no-dev
+
+# ── FastAPI wrapper app ───────────────────────────────────────────────────────
+COPY sagemaker-wrapper/magpie/app/ /opt/wrapper/app/
+
+# ── Entrypoint ────────────────────────────────────────────────────────────────
+COPY sagemaker-wrapper/magpie/entrypoint.sh /opt/wrapper/entrypoint.sh
+RUN chmod +x /opt/wrapper/entrypoint.sh
+
+# SageMaker expects the container to listen on port 8080.
+# The bidirectional-streaming label tells SageMaker to enable the HTTP/2 bidi
+# stream sidecar, which proxies to ws://localhost:8080/invocations-bidirectional-stream.
+LABEL com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true
+EXPOSE 8080
+
+ENTRYPOINT ["/opt/wrapper/entrypoint.sh"]

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/README.md
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/README.md
@@ -1,0 +1,82 @@
+# SageMaker Wrapper — Magpie TTS
+
+SageMaker wrapper for the **NVIDIA Magpie TTS NIM** (`magpie-tts-multilingual`). Translates SageMaker's expected interface to the NIM's actual API.
+
+---
+
+## API mapping
+
+```
+SageMaker (port 8080)                        NIM (port 9000)
+────────────────────────────────────────     ──────────────────────────────────────────
+GET  /ping                               →   GET  /v1/health/ready
+POST /invocations                        →   POST /v1/audio/synthesize_online  (HTTP streaming)
+WS   /invocations-bidirectional-stream   →   WS   /v1/realtime?intent=synthesize
+```
+
+---
+
+## POST /invocations
+
+Accepts a JSON body and returns a streaming `application/octet-stream` of raw signed 16-bit mono PCM audio.
+
+**Request body (JSON):**
+```json
+{
+  "text": "Hello, world.",
+  "voice_name": "Magpie-Multilingual.EN-US.Aria",
+  "language_code": "en-US",
+  "sample_rate_hz": 22050
+}
+```
+
+**Response:** raw PCM16 mono audio stream (`application/octet-stream`).
+
+---
+
+## WS /invocations-bidirectional-stream
+
+Transparent WebSocket proxy to NIM's realtime synthesis endpoint (`/v1/realtime?intent=synthesize`).
+
+The wrapper intercepts the `session.end` message (a client-side signal to close the session) and closes the NIM WebSocket gracefully, since NIM does not understand that message type.
+
+Enabled by the container label:
+```
+com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true
+```
+
+---
+
+## Structure
+
+```
+magpie/
+├── Dockerfile            ← Extends the NIM image with the FastAPI layer
+├── entrypoint.sh         ← Starts NIM and uvicorn in parallel; supervises both
+└── app/
+    ├── main.py           ← FastAPI app: /ping, /invocations, WebSocket proxy
+    └── pyproject.toml    ← Python dependencies: fastapi, uvicorn, httpx, websockets
+```
+
+---
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `NIM_HTTP_API_PORT` | `9000` | NIM's internal HTTP port |
+| `NIM_HEALTH_PATH` | `/v1/health/ready` | NIM health check path |
+| `NGC_API_KEY` | — | Required — NIM uses this to download model weights |
+
+---
+
+## Building and deploying
+
+```bash
+./scripts/build_wrapper.sh magpie
+./scripts/push_to_ecr.sh magpie
+./scripts/create_model.sh magpie
+./scripts/create_endpoint.sh magpie
+```
+
+See [DEPLOYMENT.md](../../DEPLOYMENT.md) for the full walkthrough.

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/app/main.py
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/app/main.py
@@ -178,9 +178,7 @@ async def _nim_ws_proxy(client_ws: WebSocket, log_tag: str) -> None:
                         msg = await client_ws.receive()
                         logger.info(f"msg received {msg}")
                         if msg.get("type") == "websocket.disconnect":
-                            logger.info(
-                                f"{log_tag} — client disconnected (code {msg.get('code')})"
-                            )
+                            logger.info(f"{log_tag} — client disconnected (code {msg.get('code')})")
                             await nim_ws.close()
                             return
                         if "text" in msg:
@@ -212,9 +210,7 @@ async def _nim_ws_proxy(client_ws: WebSocket, log_tag: str) -> None:
                 except websockets.exceptions.ConnectionClosedOK:
                     logger.info(f"{log_tag} — NIM WebSocket closed normally")
                 except websockets.exceptions.ConnectionClosedError as exc:
-                    logger.warning(
-                        f"{log_tag} — NIM WebSocket closed with error: {exc}"
-                    )
+                    logger.warning(f"{log_tag} — NIM WebSocket closed with error: {exc}")
 
             await asyncio.gather(client_to_nim(), nim_to_client())
 

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/app/main.py
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/app/main.py
@@ -1,0 +1,251 @@
+"""
+SageMaker compatibility wrapper for NVIDIA Magpie TTS NIM.
+
+Translates SageMaker's expected interface to the NIM container's actual API:
+
+    SageMaker                    NIM
+    ─────────────────────────    ──────────────────────────────────
+    GET  /ping              →    GET  /v1/health/ready
+    POST /invocations       →    POST /v1/audio/synthesize_online  (HTTP streaming)
+
+The HTTP /invocations path is used with SageMaker's standard invoke-endpoint API.
+The WebSocket path is used for real-time streaming (direct access or via
+SageMaker's InvokeEndpointWithBidirectionalStream).
+"""
+
+import asyncio
+import json
+import logging
+import os
+
+import httpx
+import websockets
+import websockets.exceptions
+from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
+from fastapi.responses import StreamingResponse
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("sagemaker-wrapper")
+
+app = FastAPI(title="Magpie TTS SageMaker Wrapper")
+
+# ── NIM connection config ─────────────────────────────────────────────────────
+NIM_HTTP_PORT = int(os.environ.get("NIM_HTTP_API_PORT", "9000"))
+NIM_BASE_URL = f"http://localhost:{NIM_HTTP_PORT}"
+NIM_WS_URL = f"ws://localhost:{NIM_HTTP_PORT}"
+
+NIM_HEALTH_PATH = os.environ.get("NIM_HEALTH_PATH", "/v1/health/ready")
+NIM_SYNTHESIS_PATH = "/v1/audio/synthesize_online"
+NIM_REALTIME_PATH = "/v1/realtime"
+
+logger.info(f"NIM base URL      : {NIM_BASE_URL}")
+logger.info(f"NIM health path   : {NIM_HEALTH_PATH}")
+logger.info(f"NIM synthesis path: {NIM_SYNTHESIS_PATH}")
+logger.info(f"NIM realtime path : {NIM_REALTIME_PATH}")
+
+
+# ── Health check ──────────────────────────────────────────────────────────────
+
+
+@app.get("/ping")
+async def ping() -> Response:
+    """
+    SageMaker polls this endpoint to determine if the container is healthy.
+    Returns 200 only when NIM is fully initialized and ready to serve requests.
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{NIM_BASE_URL}{NIM_HEALTH_PATH}", timeout=5.0)
+        if resp.status_code == 200:
+            logger.debug("NIM health: ready")
+            return Response(status_code=200)
+        logger.debug(f"NIM health: not ready (status {resp.status_code})")
+    except httpx.ConnectError:
+        logger.debug("NIM health: connection refused (still starting)")
+    except httpx.TimeoutException:
+        logger.warning("NIM health: timeout")
+    except Exception as exc:
+        logger.warning(f"NIM health check error: {exc}")
+    return Response(status_code=503)
+
+
+# ── HTTP streaming inference ──────────────────────────────────────────────────
+
+
+@app.post("/invocations")
+async def invocations(request: Request) -> Response:
+    """
+    SageMaker sends all inference requests here.
+    Parses the JSON body and proxies to NIM's HTTP streaming synthesis endpoint
+    as multipart form data, streaming the raw PCM audio back to the caller.
+
+    Expected request body (JSON):
+        {
+            "text": "Hello, world.",
+            "voice_name": "Magpie-Multilingual.EN-US.Aria",
+            "language_code": "en-US",
+            "sample_rate_hz": 22050
+        }
+    """
+    body = await request.body()
+    logger.info(f"POST /invocations — {len(body)} bytes")
+
+    try:
+        params = json.loads(body)
+    except json.JSONDecodeError as exc:
+        logger.error(f"Invalid JSON body: {exc}")
+        return Response(content=b'{"error": "invalid JSON body"}', status_code=400)
+
+    text = params.get("text", "")
+    voice = params.get("voice_name", "Magpie-Multilingual.EN-US.Aria")
+    language = params.get("language_code", "en-US")
+    sample_rate = int(params.get("sample_rate_hz", 22050))
+
+    if not text:
+        return Response(content=b'{"error": "text field is required"}', status_code=400)
+
+    logger.info(f"Synthesis — voice={voice!r} lang={language} rate={sample_rate}")
+
+    async def stream_synthesis():
+        try:
+            async with httpx.AsyncClient(timeout=None) as client:
+                async with client.stream(
+                    "POST",
+                    f"{NIM_BASE_URL}{NIM_SYNTHESIS_PATH}",
+                    data={
+                        "text": text,
+                        "voice": voice,
+                        "language": language,
+                        "sample_rate_hz": str(sample_rate),
+                    },
+                ) as nim_resp:
+                    if nim_resp.status_code != 200:
+                        error_body = await nim_resp.aread()
+                        logger.error(
+                            f"NIM returned {nim_resp.status_code}: {error_body.decode(errors='replace')}"
+                        )
+                        yield error_body
+                        return
+                    logger.info(
+                        f"NIM synthesis streaming "
+                        f"(content-type: {nim_resp.headers.get('content-type', 'unknown')})"
+                    )
+                    async for chunk in nim_resp.aiter_bytes(chunk_size=4096):
+                        yield chunk
+        except httpx.ConnectError as exc:
+            logger.error(f"Cannot connect to NIM: {exc}")
+            yield b'{"error": "NIM service unavailable"}'
+        except Exception as exc:
+            logger.error(f"Synthesis error: {exc}")
+            yield b'{"error": "internal wrapper error"}'
+
+    return StreamingResponse(stream_synthesis(), media_type="application/octet-stream")
+
+
+# ── WebSocket proxy ───────────────────────────────────────────────────────────
+
+
+async def _nim_ws_proxy(client_ws: WebSocket, log_tag: str) -> None:
+    """
+    Transparent WebSocket proxy: bridges client_ws to NIM's realtime endpoint.
+
+    Forwards all frames (text and binary) in both directions without
+    modification. Used by /invocations-bidirectional-stream (SageMaker bidi stream).
+
+    NIM WebSocket protocol (client → NIM):
+        {"type": "synthesize_session.update", "session": {"input_text_synthesis": {"voice_name": ..., "language_code": ...}, "output_audio_params": {...}}}
+        {"type": "input_text.append", "text": "Hello world"}
+        {"type": "input_text.commit"}
+        {"type": "input_text.done"}
+
+    NIM WebSocket protocol (NIM → client):
+        {"type": "conversation.item.speech.data", "audio": "<base64>", "is_last_chunk": false}
+        {"type": "conversation.item.speech.completed", ...}
+        {"type": "error", ...}
+    """
+    nim_uri = f"{NIM_WS_URL}{NIM_REALTIME_PATH}?intent=synthesize"
+    logger.info(f"{log_tag} — client connected, opening NIM WebSocket at {nim_uri}")
+
+    try:
+        async with websockets.connect(nim_uri) as nim_ws:
+
+            async def client_to_nim():
+                try:
+                    while True:
+                        msg = await client_ws.receive()
+                        logger.info(f"msg received {msg}")
+                        if msg.get("type") == "websocket.disconnect":
+                            logger.info(
+                                f"{log_tag} — client disconnected (code {msg.get('code')})"
+                            )
+                            await nim_ws.close()
+                            return
+                        if "text" in msg:
+                            # Intercept session.end — close NIM WebSocket gracefully
+                            # instead of forwarding (NIM doesn't know this message type).
+                            try:
+                                if json.loads(msg["text"]).get("type") == "session.end":
+                                    logger.info(
+                                        f"{log_tag} — session.end received, closing NIM WebSocket"
+                                    )
+                                    await nim_ws.close()
+                                    return
+                            except (json.JSONDecodeError, AttributeError):
+                                pass
+                            await nim_ws.send(msg["text"])
+                        elif "bytes" in msg:
+                            await nim_ws.send(msg["bytes"])
+                except WebSocketDisconnect:
+                    logger.info(f"{log_tag} — client disconnected")
+                    await nim_ws.close()
+
+            async def nim_to_client():
+                try:
+                    async for msg in nim_ws:
+                        if isinstance(msg, str):
+                            await client_ws.send_text(msg)
+                        else:
+                            await client_ws.send_bytes(msg)
+                except websockets.exceptions.ConnectionClosedOK:
+                    logger.info(f"{log_tag} — NIM WebSocket closed normally")
+                except websockets.exceptions.ConnectionClosedError as exc:
+                    logger.warning(
+                        f"{log_tag} — NIM WebSocket closed with error: {exc}"
+                    )
+
+            await asyncio.gather(client_to_nim(), nim_to_client())
+
+    except websockets.exceptions.WebSocketException as exc:
+        logger.error(f"{log_tag} — cannot connect to NIM WebSocket: {exc}")
+        try:
+            await client_ws.close(code=1011)
+        except Exception:
+            pass
+    except Exception as exc:
+        logger.error(f"{log_tag} — unexpected error: {exc}")
+        try:
+            await client_ws.close(code=1011)
+        except Exception:
+            pass
+
+
+# Docs:
+# https://docs.aws.amazon.com/pt_br/sagemaker/latest/dg/your-algorithms-inference-code.html
+@app.websocket("/invocations-bidirectional-stream")
+async def bidi_stream_proxy(client_ws: WebSocket):
+    """
+    SageMaker bidirectional-stream endpoint → NIM realtime WebSocket proxy.
+
+    SageMaker's sidecar converts the client's HTTP/2 event stream into WebSocket
+    frames at this path before forwarding them to the container.  The wrapper
+    bridges those frames transparently to NIM's realtime WebSocket, so the
+    caller can use the NIM JSON protocol directly over SageMaker's bidi API.
+
+    Enable with the container label:
+        com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true
+    """
+    await client_ws.accept()
+    await _nim_ws_proxy(client_ws, "WS /invocations-bidirectional-stream")

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/app/pyproject.toml
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/app/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "magpie-tts-sagemaker-wrapper"
+version = "0.1.0"
+description = "SageMaker compatibility wrapper for NVIDIA Magpie TTS NIM"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.27.0",
+    "httpx>=0.27.0",
+    "websockets>=12.0",
+]

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/entrypoint.sh
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/entrypoint.sh
@@ -34,6 +34,9 @@ start_nim() {
   elif [ -f /opt/nim/start-server.sh ]; then
     echo "→ Starting NIM via /opt/nim/start-server.sh ..."
     /opt/nim/start-server.sh
+  elif [ -f /opt/nim/start_server.sh ]; then
+    echo "→ Starting NIM via /opt/nim/start_server.sh ..."
+    /opt/nim/start_server.sh
   elif [ -f /opt/nvidia/nvidia_entrypoint.sh ]; then
     echo "→ Starting NIM via /opt/nvidia/nvidia_entrypoint.sh ..."
     /opt/nvidia/nvidia_entrypoint.sh

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/entrypoint.sh
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/magpie/entrypoint.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# entrypoint.sh — Start the NVIDIA NIM server and the SageMaker wrapper side by side.
+#
+# Process layout inside the container:
+#
+#   PID 1  this script
+#   ├── NIM server (original NIM entrypoint, runs in background)
+#   │     listens on NIM_HTTP_API_PORT (default: 9000) and NIM_GRPC_API_PORT (default: 50051)
+#   └── uvicorn (FastAPI wrapper, runs in background)
+#         listens on port 8080 — SageMaker's expected port
+
+set -euo pipefail
+
+NIM_HTTP_PORT="${NIM_HTTP_API_PORT:-9000}"
+NIM_GRPC_PORT="${NIM_GRPC_API_PORT:-50051}"
+WRAPPER_PORT=8080   # SageMaker always expects port 8080
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Magpie TTS SageMaker Wrapper"
+echo ""
+echo " NIM HTTP port  : $NIM_HTTP_PORT"
+echo " NIM gRPC port  : $NIM_GRPC_PORT"
+echo " Wrapper port   : $WRAPPER_PORT  (SageMaker /ping + /invocations)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ── Start the NIM server ──────────────────────────────────────────────────────
+# We try common entrypoint locations for NVIDIA NIM containers.
+# If none match, set NIM_START_CMD in your environment to override.
+
+start_nim() {
+  if [ -n "${NIM_START_CMD:-}" ]; then
+    echo "→ Starting NIM via NIM_START_CMD: $NIM_START_CMD"
+    eval "$NIM_START_CMD"
+  elif [ -f /opt/nim/start-server.sh ]; then
+    echo "→ Starting NIM via /opt/nim/start-server.sh ..."
+    /opt/nim/start-server.sh
+  elif [ -f /opt/nvidia/nvidia_entrypoint.sh ]; then
+    echo "→ Starting NIM via /opt/nvidia/nvidia_entrypoint.sh ..."
+    /opt/nvidia/nvidia_entrypoint.sh
+  elif command -v nim_start &>/dev/null; then
+    echo "→ Starting NIM via nim_start ..."
+    nim_start
+  else
+    echo ""
+    echo "ERROR: Could not find NIM start command."
+    echo "  Inspect the NIM image to find its entrypoint:"
+    echo "    docker inspect nvcr.io/nim/nvidia/magpie-tts-multilingual:latest \\"
+    echo "      --format='{{.Config.Entrypoint}} {{.Config.Cmd}}'"
+    echo "  Then set NIM_START_CMD in your SageMaker model environment."
+    exit 1
+  fi
+}
+
+start_nim &
+NIM_PID=$!
+echo "  NIM PID: $NIM_PID"
+
+# ── Start the FastAPI wrapper ─────────────────────────────────────────────────
+echo "→ Starting SageMaker wrapper on port $WRAPPER_PORT ..."
+cd /opt/wrapper
+.venv/bin/uvicorn app.main:app \
+  --host 0.0.0.0 \
+  --port "$WRAPPER_PORT" \
+  --log-level info \
+  --no-access-log &
+UVICORN_PID=$!
+echo "  Uvicorn PID: $UVICORN_PID"
+
+echo ""
+echo "  Both processes started. NIM is initializing (may take up to 30 minutes)."
+echo "  SageMaker will poll /ping — it will return 503 until NIM is ready."
+echo ""
+
+# ── Supervise: exit if either process dies ────────────────────────────────────
+trap 'echo "Shutting down..."; kill "$NIM_PID" "$UVICORN_PID" 2>/dev/null; wait' SIGTERM SIGINT
+
+# Wait for either process to exit; if one dies, kill the other and exit
+wait -n "$NIM_PID" "$UVICORN_PID" 2>/dev/null || true
+
+EXIT_CODE=$?
+echo "A child process exited (code $EXIT_CODE). Shutting down remaining processes."
+kill "$NIM_PID" "$UVICORN_PID" 2>/dev/null || true
+wait "$NIM_PID" "$UVICORN_PID" 2>/dev/null || true
+exit "$EXIT_CODE"

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/Dockerfile
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/Dockerfile
@@ -1,0 +1,56 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Nemotron ASR SageMaker Wrapper
+#
+# Extends the NVIDIA Nemotron ASR Streaming NIM image with a FastAPI layer that
+# translates SageMaker's expected interface into NIM's actual API:
+#
+#   GET  /ping                              → NIM GET  /v1/health             (HTTP :9000)
+#   POST /invocations                       → NIM WS   /v1/realtime?intent=transcription (:9000)
+#   WS   /invocations-bidirectional-stream  → NIM WS   /v1/realtime?intent=transcription (:9000)
+#
+# The NIM server runs internally on port 9000 (its default).
+# The FastAPI wrapper runs on port 8080, which SageMaker expects.
+#
+# Nemotron ASR Streaming requires the following environment variables at runtime:
+#   NIM_TAGS_SELECTOR=mode=str
+#   CONTAINER_ID=nemotron-asr-streaming
+#
+# Build with:
+#   ./scripts/build_wrapper.sh nemotron-asr
+# ─────────────────────────────────────────────────────────────────────────────
+
+# NIM_IMAGE is the local image pulled by pull_nim.sh.
+# Docker uses the local cache — it does not re-pull from NVIDIA's registry.
+ARG NIM_IMAGE=nvcr.io/nim/nvidia/nemotron-asr-streaming:latest
+FROM ${NIM_IMAGE}
+
+# NIM's original entrypoint + cmd — detected by build_wrapper.sh via docker inspect
+# and baked in here so entrypoint.sh knows how to start NIM without guessing.
+ARG NIM_START_CMD=""
+ENV NIM_START_CMD=${NIM_START_CMD}
+
+# ── uv (fast Python package manager — no apt-get needed) ─────────────────────
+# Copy the uv binary from its official image. Runs as root so we can write to
+# /opt/wrapper and /usr/local/bin.
+USER root
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# ── FastAPI wrapper dependencies ──────────────────────────────────────────────
+WORKDIR /opt/wrapper
+COPY sagemaker-wrapper/nemotron-asr/app/pyproject.toml /opt/wrapper/pyproject.toml
+RUN uv sync --no-dev
+
+# ── FastAPI wrapper app ───────────────────────────────────────────────────────
+COPY sagemaker-wrapper/nemotron-asr/app/ /opt/wrapper/app/
+
+# ── Entrypoint ────────────────────────────────────────────────────────────────
+COPY sagemaker-wrapper/nemotron-asr/entrypoint.sh /opt/wrapper/entrypoint.sh
+RUN chmod +x /opt/wrapper/entrypoint.sh
+
+# SageMaker expects the container to listen on port 8080.
+# The bidirectional-streaming label tells SageMaker to enable the HTTP/2 bidi
+# stream sidecar, which proxies to ws://localhost:8080/invocations-bidirectional-stream.
+LABEL com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true
+EXPOSE 8080
+
+ENTRYPOINT ["/opt/wrapper/entrypoint.sh"]

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/README.md
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/README.md
@@ -1,0 +1,91 @@
+# SageMaker Wrapper — Nemotron ASR Streaming
+
+SageMaker wrapper for the **NVIDIA Nemotron ASR Streaming NIM** (`nemotron-asr-streaming`). Translates SageMaker's expected interface to the NIM's actual API.
+
+---
+
+## API mapping
+
+```
+SageMaker (port 8080)                        NIM (port 9000)
+────────────────────────────────────────     ──────────────────────────────────────────
+GET  /ping                               →   GET  /v1/health/ready
+POST /invocations                        →   410 Not Supported (use bidi-stream)
+WS   /invocations-bidirectional-stream   →   WS   /v1/realtime?intent=transcription
+```
+
+---
+
+## POST /invocations
+
+Not supported. Nemotron ASR Streaming is a realtime model — batch transcription via `POST /invocations` is not available. Returns `410 Gone` with a message directing the caller to use `InvokeEndpointWithBidirectionalStream` instead.
+
+---
+
+## WS /invocations-bidirectional-stream
+
+Transparent WebSocket proxy to NIM's realtime transcription endpoint (`/v1/realtime?intent=transcription`). All frames are forwarded in both directions without modification.
+
+**Client → NIM messages:**
+```json
+{"type": "transcription_session.update", "session": {...}}
+{"type": "input_audio_buffer.append", "audio": "<base64 PCM16>"}
+{"type": "input_audio_buffer.commit"}
+{"type": "input_audio_buffer.done"}
+{"type": "input_audio_buffer.clear"}
+```
+
+**NIM → client messages:**
+```json
+{"type": "conversation.created", ...}
+{"type": "transcription_session.updated", ...}
+{"type": "input_audio_buffer.committed", ...}
+{"type": "conversation.item.input_audio_transcription.delta", "delta": "..."}
+{"type": "conversation.item.input_audio_transcription.completed", "transcript": "..."}
+{"type": "conversation.item.input_audio_transcription.failed", ...}
+{"type": "error", ...}
+```
+
+Enabled by the container label:
+```
+com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true
+```
+
+---
+
+## Structure
+
+```
+nemotron-asr/
+├── Dockerfile            ← Extends the NIM image with the FastAPI layer
+├── entrypoint.sh         ← Starts NIM and uvicorn in parallel; supervises both
+└── app/
+    ├── main.py           ← FastAPI app: /ping (health), /invocations (unsupported), WebSocket proxy
+    └── pyproject.toml    ← Python dependencies: fastapi, uvicorn, httpx, websockets
+```
+
+---
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `NIM_HTTP_API_PORT` | `9000` | NIM's internal HTTP port |
+| `NIM_HEALTH_PATH` | `/v1/health/ready` | NIM health check path |
+| `NIM_TAGS_SELECTOR` | — | Must be set to `mode=str` to enable streaming mode |
+| `NGC_API_KEY` | — | Required — NIM uses this to download model weights |
+
+> **Important:** `NIM_TAGS_SELECTOR=mode=str` is required for the Nemotron ASR Streaming NIM. It is injected automatically by `scripts/create_model.sh`.
+
+---
+
+## Building and deploying
+
+```bash
+./scripts/build_wrapper.sh nemotron-asr
+./scripts/push_to_ecr.sh nemotron-asr
+./scripts/create_model.sh nemotron-asr
+./scripts/create_endpoint.sh nemotron-asr
+```
+
+See [DEPLOYMENT.md](../../DEPLOYMENT.md) for the full walkthrough.

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/app/main.py
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/app/main.py
@@ -155,9 +155,7 @@ async def _nim_ws_proxy(client_ws: WebSocket, log_tag: str) -> None:
                         msg = await client_ws.receive()
                         logger.info(f"msg received {msg}")
                         if msg.get("type") == "websocket.disconnect":
-                            logger.info(
-                                f"{log_tag} — client disconnected (code {msg.get('code')})"
-                            )
+                            logger.info(f"{log_tag} — client disconnected (code {msg.get('code')})")
                             await nim_ws.close()
                             return
                         if "text" in msg:
@@ -189,9 +187,7 @@ async def _nim_ws_proxy(client_ws: WebSocket, log_tag: str) -> None:
                 except websockets.exceptions.ConnectionClosedOK:
                     logger.info(f"{log_tag} — NIM WebSocket closed normally")
                 except websockets.exceptions.ConnectionClosedError as exc:
-                    logger.warning(
-                        f"{log_tag} — NIM WebSocket closed with error: {exc}"
-                    )
+                    logger.warning(f"{log_tag} — NIM WebSocket closed with error: {exc}")
 
             await asyncio.gather(client_to_nim(), nim_to_client())
 

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/app/main.py
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/app/main.py
@@ -1,0 +1,228 @@
+"""
+SageMaker compatibility wrapper for NVIDIA Nemotron ASR Streaming NIM.
+
+Translates SageMaker's expected interface to the NIM container's actual API:
+
+    SageMaker                            NIM
+    ─────────────────────────────────    ──────────────────────────────────────────
+    GET  /ping                      →    GET  /v1/health/ready
+    POST /invocations               →    410 Not Supported (use bidi-stream)
+    WS   /invocations-bidirectional-stream → WS /v1/realtime?intent=transcription
+
+The NIM server runs internally on port 9000 (its default).
+The FastAPI wrapper runs on port 8080, which SageMaker expects.
+
+NIM endpoints used by this wrapper:
+    GET  /v1/health/ready                   ← polled by /ping
+    WS   /v1/realtime?intent=transcription  ← proxied by /invocations-bidirectional-stream
+
+WebSocket protocol (client → NIM, forwarded transparently):
+    {"type": "transcription_session.update", "session": {...}}
+    {"type": "input_audio_buffer.append", "audio": "<base64 PCM16>"}
+    {"type": "input_audio_buffer.commit"}
+    {"type": "input_audio_buffer.done"}
+    {"type": "input_audio_buffer.clear"}
+
+WebSocket protocol (NIM → client, forwarded transparently):
+    {"type": "conversation.created", ...}
+    {"type": "transcription_session.updated", ...}
+    {"type": "input_audio_buffer.committed", ...}
+    {"type": "conversation.item.input_audio_transcription.delta", "delta": "..."}
+    {"type": "conversation.item.input_audio_transcription.completed", "transcript": "..."}
+    {"type": "conversation.item.input_audio_transcription.failed", ...}
+    {"type": "error", ...}
+"""
+
+import asyncio
+import json
+import logging
+import os
+
+import httpx
+import websockets
+import websockets.exceptions
+from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("sagemaker-wrapper")
+
+app = FastAPI(title="Nemotron ASR SageMaker Wrapper")
+
+# ── NIM connection config ─────────────────────────────────────────────────────
+NIM_HTTP_PORT = int(os.environ.get("NIM_HTTP_API_PORT", "9000"))
+NIM_BASE_URL = f"http://localhost:{NIM_HTTP_PORT}"
+NIM_WS_URL = f"ws://localhost:{NIM_HTTP_PORT}"
+
+NIM_HEALTH_PATH = os.environ.get("NIM_HEALTH_PATH", "/v1/health/ready")
+NIM_REALTIME_PATH = "/v1/realtime"
+
+logger.info(f"NIM base URL         : {NIM_BASE_URL}")
+logger.info(f"NIM health path      : {NIM_HEALTH_PATH}")
+logger.info(f"NIM realtime WS      : {NIM_REALTIME_PATH}?intent=transcription")
+
+
+# ── Health check ──────────────────────────────────────────────────────────────
+
+
+@app.get("/ping")
+async def ping() -> Response:
+    """
+    SageMaker polls this endpoint to determine if the container is healthy.
+    Returns 200 only when NIM is fully initialized and ready to serve requests.
+
+    NIM health endpoint: GET /v1/health/ready
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{NIM_BASE_URL}{NIM_HEALTH_PATH}", timeout=5.0)
+        if resp.status_code == 200:
+            logger.debug("NIM health: ready")
+            return Response(status_code=200)
+        logger.debug(f"NIM health: not ready (status {resp.status_code})")
+    except httpx.ConnectError:
+        logger.debug("NIM health: connection refused (still starting)")
+    except httpx.TimeoutException:
+        logger.warning("NIM health: timeout")
+    except Exception as exc:
+        logger.warning(f"NIM health check error: {exc}")
+    return Response(status_code=503)
+
+
+# ── HTTP batch transcription (not supported) ──────────────────────────────────
+
+
+@app.post("/invocations")
+async def invocations(request: Request) -> Response:
+    """
+    Batch transcription via POST /invocations is not supported.
+
+    Nemotron ASR Streaming is a realtime streaming model — use the
+    bidirectional-stream endpoint instead:
+
+        InvokeEndpointWithBidirectionalStream → /invocations-bidirectional-stream
+    """
+    logger.warning("POST /invocations called — not supported, returning 410")
+    return Response(
+        content=json.dumps(
+            {
+                "error": "POST /invocations is not supported for Nemotron ASR Streaming. "
+                "Use InvokeEndpointWithBidirectionalStream (/invocations-bidirectional-stream) instead."
+            }
+        ).encode(),
+        status_code=410,
+        media_type="application/json",
+    )
+
+
+# ── WebSocket proxy ───────────────────────────────────────────────────────────
+
+
+async def _nim_ws_proxy(client_ws: WebSocket, log_tag: str) -> None:
+    """
+    Transparent WebSocket proxy: bridges client_ws to NIM's realtime transcription endpoint.
+
+    Forwards all frames (text and binary) in both directions without modification.
+    Used by /invocations-bidirectional-stream (SageMaker bidi stream).
+
+    NIM WebSocket protocol (client → NIM):
+        {"type": "transcription_session.update", "session": {...}}
+        {"type": "input_audio_buffer.append", "audio": "<base64 PCM16>"}
+        {"type": "input_audio_buffer.commit"}
+        {"type": "input_audio_buffer.done"}
+        {"type": "input_audio_buffer.clear"}
+
+    NIM WebSocket protocol (NIM → client):
+        {"type": "conversation.created", ...}
+        {"type": "transcription_session.updated", ...}
+        {"type": "input_audio_buffer.committed", ...}
+        {"type": "conversation.item.input_audio_transcription.delta", "delta": "..."}
+        {"type": "conversation.item.input_audio_transcription.completed", "transcript": "..."}
+        {"type": "conversation.item.input_audio_transcription.failed", ...}
+        {"type": "error", ...}
+    """
+    nim_uri = f"{NIM_WS_URL}{NIM_REALTIME_PATH}?intent=transcription"
+    logger.info(f"{log_tag} — client connected, opening NIM WebSocket at {nim_uri}")
+
+    try:
+        async with websockets.connect(nim_uri) as nim_ws:
+
+            async def client_to_nim():
+                try:
+                    while True:
+                        msg = await client_ws.receive()
+                        logger.info(f"msg received {msg}")
+                        if msg.get("type") == "websocket.disconnect":
+                            logger.info(
+                                f"{log_tag} — client disconnected (code {msg.get('code')})"
+                            )
+                            await nim_ws.close()
+                            return
+                        if "text" in msg:
+                            # Intercept session.end — close NIM WebSocket gracefully
+                            # instead of forwarding (NIM doesn't know this message type).
+                            try:
+                                if json.loads(msg["text"]).get("type") == "session.end":
+                                    logger.info(
+                                        f"{log_tag} — session.end received, closing NIM WebSocket"
+                                    )
+                                    await nim_ws.close()
+                                    return
+                            except (json.JSONDecodeError, AttributeError):
+                                pass
+                            await nim_ws.send(msg["text"])
+                        elif "bytes" in msg:
+                            await nim_ws.send(msg["bytes"])
+                except WebSocketDisconnect:
+                    logger.info(f"{log_tag} — client disconnected")
+                    await nim_ws.close()
+
+            async def nim_to_client():
+                try:
+                    async for msg in nim_ws:
+                        if isinstance(msg, str):
+                            await client_ws.send_text(msg)
+                        else:
+                            await client_ws.send_bytes(msg)
+                except websockets.exceptions.ConnectionClosedOK:
+                    logger.info(f"{log_tag} — NIM WebSocket closed normally")
+                except websockets.exceptions.ConnectionClosedError as exc:
+                    logger.warning(
+                        f"{log_tag} — NIM WebSocket closed with error: {exc}"
+                    )
+
+            await asyncio.gather(client_to_nim(), nim_to_client())
+
+    except websockets.exceptions.WebSocketException as exc:
+        logger.error(f"{log_tag} — cannot connect to NIM WebSocket: {exc}")
+        try:
+            await client_ws.close(code=1011)
+        except Exception:
+            pass
+    except Exception as exc:
+        logger.error(f"{log_tag} — unexpected error: {exc}")
+        try:
+            await client_ws.close(code=1011)
+        except Exception:
+            pass
+
+
+# Docs:
+# https://docs.aws.amazon.com/pt_br/sagemaker/latest/dg/your-algorithms-inference-code.html
+@app.websocket("/invocations-bidirectional-stream")
+async def bidi_stream_proxy(client_ws: WebSocket):
+    """
+    SageMaker bidirectional-stream endpoint → NIM realtime WebSocket proxy.
+
+    SageMaker's sidecar converts the client's HTTP/2 event stream into WebSocket
+    frames at this path before forwarding them to the container. The wrapper
+    bridges those frames transparently to NIM's realtime WebSocket, so the
+    caller can use the NIM ASR JSON protocol directly over SageMaker's bidi API.
+
+    Enable with the container label:
+        com.amazonaws.sagemaker.capabilities.bidirectional-streaming=true
+    """
+    await client_ws.accept()
+    await _nim_ws_proxy(client_ws, "WS /invocations-bidirectional-stream")

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/app/pyproject.toml
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/app/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "nemotron-asr-sagemaker-wrapper"
+version = "0.1.0"
+description = "SageMaker compatibility wrapper for NVIDIA Nemotron ASR Streaming NIM"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.27.0",
+    "httpx>=0.27.0",
+    "websockets>=12.0",
+]

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/entrypoint.sh
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/entrypoint.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# entrypoint.sh — Start the NVIDIA NIM server and the SageMaker wrapper side by side.
+#
+# Process layout inside the container:
+#
+#   PID 1  this script
+#   ├── NIM server (original NIM entrypoint, runs in background)
+#   │     listens on NIM_HTTP_API_PORT (default: 9000) and NIM_GRPC_API_PORT (default: 50051)
+#   └── uvicorn (FastAPI wrapper, runs in background)
+#         listens on port 8080 — SageMaker's expected port
+
+set -euo pipefail
+
+NIM_HTTP_PORT="${NIM_HTTP_API_PORT:-9000}"
+NIM_GRPC_PORT="${NIM_GRPC_API_PORT:-50051}"
+WRAPPER_PORT=8080   # SageMaker always expects port 8080
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Nemotron ASR SageMaker Wrapper"
+echo ""
+echo " NIM HTTP port  : $NIM_HTTP_PORT"
+echo " NIM gRPC port  : $NIM_GRPC_PORT"
+echo " Wrapper port   : $WRAPPER_PORT  (SageMaker /ping + /invocations)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ── Start the NIM server ──────────────────────────────────────────────────────
+# We try common entrypoint locations for NVIDIA NIM containers.
+# If none match, set NIM_START_CMD in your environment to override.
+#
+# Note: Nemotron ASR Streaming requires NIM_TAGS_SELECTOR="mode=str" to be set
+# in the container environment for streaming mode.
+
+start_nim() {
+  if [ -n "${NIM_START_CMD:-}" ]; then
+    echo "→ Starting NIM via NIM_START_CMD: $NIM_START_CMD"
+    eval "$NIM_START_CMD"
+  elif [ -f /opt/nim/start-server.sh ]; then
+    echo "→ Starting NIM via /opt/nim/start-server.sh ..."
+    /opt/nim/start-server.sh
+  elif [ -f /opt/nvidia/nvidia_entrypoint.sh ]; then
+    echo "→ Starting NIM via /opt/nvidia/nvidia_entrypoint.sh ..."
+    /opt/nvidia/nvidia_entrypoint.sh
+  elif command -v nim_start &>/dev/null; then
+    echo "→ Starting NIM via nim_start ..."
+    nim_start
+  else
+    echo ""
+    echo "ERROR: Could not find NIM start command."
+    echo "  Inspect the NIM image to find its entrypoint:"
+    echo "    docker inspect nvcr.io/nim/nvidia/nemotron-asr-streaming:latest \\"
+    echo "      --format='{{.Config.Entrypoint}} {{.Config.Cmd}}'"
+    echo "  Then set NIM_START_CMD in your SageMaker model environment."
+    exit 1
+  fi
+}
+
+start_nim &
+NIM_PID=$!
+echo "  NIM PID: $NIM_PID"
+
+# ── Start the FastAPI wrapper ─────────────────────────────────────────────────
+echo "→ Starting SageMaker wrapper on port $WRAPPER_PORT ..."
+cd /opt/wrapper
+.venv/bin/uvicorn app.main:app \
+  --host 0.0.0.0 \
+  --port "$WRAPPER_PORT" \
+  --log-level info \
+  --no-access-log &
+UVICORN_PID=$!
+echo "  Uvicorn PID: $UVICORN_PID"
+
+echo ""
+echo "  Both processes started. NIM is initializing (may take several minutes)."
+echo "  SageMaker will poll /ping — it will return 503 until NIM is ready."
+echo ""
+
+# ── Supervise: exit if either process dies ────────────────────────────────────
+trap 'echo "Shutting down..."; kill "$NIM_PID" "$UVICORN_PID" 2>/dev/null; wait' SIGTERM SIGINT
+
+# Wait for either process to exit; if one dies, kill the other and exit
+wait -n "$NIM_PID" "$UVICORN_PID" 2>/dev/null || true
+
+EXIT_CODE=$?
+echo "A child process exited (code $EXIT_CODE). Shutting down remaining processes."
+kill "$NIM_PID" "$UVICORN_PID" 2>/dev/null || true
+wait "$NIM_PID" "$UVICORN_PID" 2>/dev/null || true
+exit "$EXIT_CODE"

--- a/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/entrypoint.sh
+++ b/deployment/aws-sagemaker-nvidia/sagemaker-wrapper/nemotron-asr/entrypoint.sh
@@ -37,6 +37,9 @@ start_nim() {
   elif [ -f /opt/nim/start-server.sh ]; then
     echo "→ Starting NIM via /opt/nim/start-server.sh ..."
     /opt/nim/start-server.sh
+  elif [ -f /opt/nim/start_server.sh ]; then
+    echo "→ Starting NIM via /opt/nim/start_server.sh ..."
+    /opt/nim/start_server.sh
   elif [ -f /opt/nvidia/nvidia_entrypoint.sh ]; then
     echo "→ Starting NIM via /opt/nvidia/nvidia_entrypoint.sh ..."
     /opt/nvidia/nvidia_entrypoint.sh

--- a/deployment/aws-sagemaker-nvidia/scripts/build_wrapper.sh
+++ b/deployment/aws-sagemaker-nvidia/scripts/build_wrapper.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# build_wrapper.sh — Build a SageMaker wrapper Docker image
+#
+# Extends a locally cached NVIDIA NIM image with a FastAPI layer that
+# translates SageMaker's /ping and /invocations into the NIM's actual API.
+#
+# Docker uses the locally cached NIM image — it does NOT re-pull from NVIDIA's
+# registry. Run pull_nim.sh first to ensure the image is present locally.
+#
+# Usage:
+#   ./scripts/build_wrapper.sh                    # interactive prompt to choose NIM
+#   ./scripts/build_wrapper.sh magpie             # Magpie TTS, uses MAGPIE_IMAGE_TAG or 'latest'
+#   ./scripts/build_wrapper.sh magpie 1.7.0       # Magpie TTS, specific NIM version
+#   ./scripts/build_wrapper.sh nemotron-asr       # Nemotron ASR, uses NEMOTRON_ASR_IMAGE_TAG or 'latest'
+#   ./scripts/build_wrapper.sh nemotron-asr latest # Nemotron ASR, specific NIM version
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# ── Load .env ─────────────────────────────────────────────────────────────────
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+# ── Resolve NIM type ──────────────────────────────────────────────────────────
+NIM_TYPE="${1:-}"
+
+if [ -z "$NIM_TYPE" ]; then
+  echo ""
+  echo "Which NIM wrapper would you like to build?"
+  echo ""
+  echo "  1) magpie       — Magpie TTS (text-to-speech)"
+  echo "  2) nemotron-asr — Nemotron ASR Streaming (speech-to-text)"
+  echo ""
+  read -rp "Enter choice [1/2] or name [magpie/nemotron-asr]: " NIM_CHOICE
+  echo ""
+  case "$NIM_CHOICE" in
+    1|magpie)        NIM_TYPE="magpie" ;;
+    2|nemotron-asr)  NIM_TYPE="nemotron-asr" ;;
+    *)
+      echo "ERROR: Invalid choice '$NIM_CHOICE'. Aborting."
+      exit 1
+      ;;
+  esac
+fi
+
+case "$NIM_TYPE" in
+  magpie)
+    TAG="${2:-${MAGPIE_IMAGE_TAG:-latest}}"
+    NIM_IMAGE="nvcr.io/nim/nvidia/magpie-tts-multilingual:$TAG"
+    WRAPPER_REPO="${ECR_MAGPIE_WRAPPER_REPO_NAME:-magpie-tts-sagemaker}"
+    DOCKERFILE="$ROOT_DIR/sagemaker-wrapper/magpie/Dockerfile"
+    PULL_HINT="./scripts/pull_nim.sh magpie $TAG"
+    ;;
+  nemotron-asr)
+    TAG="${2:-${NEMOTRON_ASR_IMAGE_TAG:-latest}}"
+    NIM_IMAGE="nvcr.io/nim/nvidia/nemotron-asr-streaming:$TAG"
+    WRAPPER_REPO="${ECR_ASR_WRAPPER_REPO_NAME:-nemotron-asr-sagemaker}"
+    DOCKERFILE="$ROOT_DIR/sagemaker-wrapper/nemotron-asr/Dockerfile"
+    PULL_HINT="./scripts/pull_nim.sh nemotron-asr $TAG"
+    ;;
+  *)
+    echo "ERROR: Unknown NIM type '$NIM_TYPE'."
+    echo ""
+    echo "  Usage:"
+    echo "    ./scripts/build_wrapper.sh magpie [tag]"
+    echo "    ./scripts/build_wrapper.sh nemotron-asr [tag]"
+    echo ""
+    exit 1
+    ;;
+esac
+
+WRAPPER_IMAGE="$WRAPPER_REPO:$TAG"
+
+echo ""
+echo "NIM base image : $NIM_IMAGE  (local cache)"
+echo "Wrapper image  : $WRAPPER_IMAGE"
+echo ""
+
+# ── Check NIM image exists locally ───────────────────────────────────────────
+if ! docker image inspect "$NIM_IMAGE" &>/dev/null; then
+  echo "ERROR: NIM image '$NIM_IMAGE' not found locally."
+  echo "  Run first: $PULL_HINT"
+  exit 1
+fi
+
+# ── Auto-detect NIM entrypoint ────────────────────────────────────────────────
+# Inspect the local NIM image to find its original ENTRYPOINT + CMD.
+# Baked in as NIM_START_CMD so entrypoint.sh knows how to start NIM.
+NIM_ENTRYPOINT=$(docker inspect "$NIM_IMAGE" \
+  --format='{{range .Config.Entrypoint}}{{.}} {{end}}' 2>/dev/null | xargs || true)
+NIM_CMD=$(docker inspect "$NIM_IMAGE" \
+  --format='{{range .Config.Cmd}}{{.}} {{end}}' 2>/dev/null | xargs || true)
+
+if [ -n "$NIM_ENTRYPOINT" ]; then
+  NIM_START_CMD="$NIM_ENTRYPOINT $NIM_CMD"
+elif [ -n "$NIM_CMD" ]; then
+  NIM_START_CMD="$NIM_CMD"
+else
+  NIM_START_CMD=""
+fi
+NIM_START_CMD=$(echo "$NIM_START_CMD" | xargs)
+
+if [ -n "$NIM_START_CMD" ]; then
+  echo "  Detected NIM start command: $NIM_START_CMD"
+else
+  echo "  WARNING: Could not detect NIM start command."
+  echo "  entrypoint.sh will try common paths at runtime."
+fi
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "→ Building wrapper image (platform: linux/amd64) ..."
+echo "  This may take a few minutes ..."
+echo ""
+
+docker build \
+  --platform linux/amd64 \
+  --provenance=false \
+  --build-arg "NIM_IMAGE=$NIM_IMAGE" \
+  --build-arg "NIM_START_CMD=$NIM_START_CMD" \
+  --file "$DOCKERFILE" \
+  --tag "$WRAPPER_IMAGE" \
+  "$ROOT_DIR"
+
+echo ""
+echo "✓ Built: $WRAPPER_IMAGE"
+echo ""
+echo "  Next step: push to ECR:"
+echo "    ./scripts/push_to_ecr.sh $NIM_TYPE $TAG"

--- a/deployment/aws-sagemaker-nvidia/scripts/build_wrapper.sh
+++ b/deployment/aws-sagemaker-nvidia/scripts/build_wrapper.sh
@@ -92,6 +92,10 @@ fi
 # ── Auto-detect NIM entrypoint ────────────────────────────────────────────────
 # Inspect the local NIM image to find its original ENTRYPOINT + CMD.
 # Baked in as NIM_START_CMD so entrypoint.sh knows how to start NIM.
+#
+# Note: docker inspect returns empty Config for manifest-list images (multi-arch
+# images stored with the containerd backend). In that case we fall back to
+# running the image and probing well-known start-script paths.
 NIM_ENTRYPOINT=$(docker inspect "$NIM_IMAGE" \
   --format='{{range .Config.Entrypoint}}{{.}} {{end}}' 2>/dev/null | xargs || true)
 NIM_CMD=$(docker inspect "$NIM_IMAGE" \
@@ -105,6 +109,17 @@ else
   NIM_START_CMD=""
 fi
 NIM_START_CMD=$(echo "$NIM_START_CMD" | xargs)
+
+# Fallback: probe well-known paths inside the container when docker inspect
+# returned nothing (happens with manifest-list images on containerd backends).
+if [ -z "$NIM_START_CMD" ]; then
+  echo "  docker inspect returned empty config (manifest-list image). Probing container..."
+  NIM_START_CMD=$(docker run --rm --platform linux/amd64 \
+    --entrypoint /bin/sh "$NIM_IMAGE" \
+    -c 'for f in /opt/nim/start_server.sh /opt/nim/start-server.sh; do
+          [ -f "$f" ] && echo "$f" && exit 0
+        done' 2>/dev/null | tr -d '[:space:]' || true)
+fi
 
 if [ -n "$NIM_START_CMD" ]; then
   echo "  Detected NIM start command: $NIM_START_CMD"

--- a/deployment/aws-sagemaker-nvidia/scripts/create_endpoint.sh
+++ b/deployment/aws-sagemaker-nvidia/scripts/create_endpoint.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# create_endpoint.sh — Create a SageMaker endpoint config and deploy the endpoint
+#
+# Combines both steps (endpoint config + endpoint creation) since they are
+# always done together. Waits until the endpoint reaches InService.
+#
+# Usage:
+#   ./scripts/create_endpoint.sh              # interactive prompt to choose NIM
+#   ./scripts/create_endpoint.sh magpie       # Magpie TTS
+#   ./scripts/create_endpoint.sh nemotron-asr # Nemotron ASR Streaming
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# ── Load .env ─────────────────────────────────────────────────────────────────
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+# ── Resolve NIM type ──────────────────────────────────────────────────────────
+NIM_TYPE="${1:-}"
+
+if [ -z "$NIM_TYPE" ]; then
+  echo ""
+  echo "Which NIM endpoint would you like to deploy?"
+  echo ""
+  echo "  1) magpie       — Magpie TTS (text-to-speech)"
+  echo "  2) nemotron-asr — Nemotron ASR Streaming (speech-to-text)"
+  echo ""
+  read -rp "Enter choice [1/2] or name [magpie/nemotron-asr]: " NIM_CHOICE
+  echo ""
+  case "$NIM_CHOICE" in
+    1|magpie)        NIM_TYPE="magpie" ;;
+    2|nemotron-asr)  NIM_TYPE="nemotron-asr" ;;
+    *)
+      echo "ERROR: Invalid choice '$NIM_CHOICE'. Aborting."
+      exit 1
+      ;;
+  esac
+fi
+
+case "$NIM_TYPE" in
+  magpie)
+    MODEL_NAME="${SAGEMAKER_MAGPIE_MODEL_NAME:-}"
+    ENDPOINT_CONFIG_NAME="${SAGEMAKER_MAGPIE_ENDPOINT_CONFIG_NAME:-}"
+    ENDPOINT_NAME="${SAGEMAKER_MAGPIE_ENDPOINT_NAME:-}"
+    INSTANCE_TYPE="${SAGEMAKER_MAGPIE_INSTANCE_TYPE:-}"
+    INSTANCE_COUNT="${SAGEMAKER_MAGPIE_INSTANCE_COUNT:-}"
+    MODEL_NAME_VAR="SAGEMAKER_MAGPIE_MODEL_NAME  ← run scripts/create_model.sh magpie first"
+    ;;
+  nemotron-asr)
+    MODEL_NAME="${SAGEMAKER_ASR_MODEL_NAME:-}"
+    ENDPOINT_CONFIG_NAME="${SAGEMAKER_ASR_ENDPOINT_CONFIG_NAME:-}"
+    ENDPOINT_NAME="${SAGEMAKER_ASR_ENDPOINT_NAME:-}"
+    INSTANCE_TYPE="${SAGEMAKER_ASR_INSTANCE_TYPE:-}"
+    INSTANCE_COUNT="${SAGEMAKER_ASR_INSTANCE_COUNT:-}"
+    MODEL_NAME_VAR="SAGEMAKER_ASR_MODEL_NAME  ← run scripts/create_model.sh nemotron-asr first"
+    ;;
+  *)
+    echo "ERROR: Unknown NIM type '$NIM_TYPE'."
+    echo ""
+    echo "  Usage:"
+    echo "    ./scripts/create_endpoint.sh magpie"
+    echo "    ./scripts/create_endpoint.sh nemotron-asr"
+    echo ""
+    exit 1
+    ;;
+esac
+
+# ── Validate required vars ────────────────────────────────────────────────────
+MISSING=()
+[ -z "${AWS_ACCESS_KEY_ID:-}" ]   && MISSING+=("AWS_ACCESS_KEY_ID")
+[ -z "${AWS_SECRET_ACCESS_KEY:-}" ] && MISSING+=("AWS_SECRET_ACCESS_KEY")
+[ -z "${AWS_REGION:-}" ]          && MISSING+=("AWS_REGION")
+[ -z "$MODEL_NAME" ]              && MISSING+=("$MODEL_NAME_VAR")
+[ -z "$ENDPOINT_CONFIG_NAME" ]    && MISSING+=("${NIM_TYPE^^}_ENDPOINT_CONFIG_NAME  (e.g. SAGEMAKER_ASR_ENDPOINT_CONFIG_NAME)")
+[ -z "$ENDPOINT_NAME" ]           && MISSING+=("${NIM_TYPE^^}_ENDPOINT_NAME  (e.g. SAGEMAKER_ASR_ENDPOINT_NAME)")
+[ -z "$INSTANCE_TYPE" ]           && MISSING+=("${NIM_TYPE^^}_INSTANCE_TYPE  (e.g. SAGEMAKER_ASR_INSTANCE_TYPE)")
+[ -z "$INSTANCE_COUNT" ]          && MISSING+=("${NIM_TYPE^^}_INSTANCE_COUNT  (e.g. SAGEMAKER_ASR_INSTANCE_COUNT)")
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo ""
+  echo "ERROR: Missing required variables in .env:"
+  for VAR in "${MISSING[@]}"; do echo "  - $VAR"; done
+  echo ""
+  exit 1
+fi
+
+# ── Confirm ───────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Creating SageMaker Endpoint  [$NIM_TYPE]"
+echo ""
+echo " Model          : $MODEL_NAME"
+echo " Endpoint config: $ENDPOINT_CONFIG_NAME"
+echo " Endpoint name  : $ENDPOINT_NAME"
+echo " Instance type  : $INSTANCE_TYPE"
+echo " Instance count : $INSTANCE_COUNT"
+echo " Startup timeout: ${SAGEMAKER_CONTAINER_STARTUP_TIMEOUT:-3600}s (NIM can take up to 60 min)"
+echo " Region         : $AWS_REGION"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+read -r -p "Continue? [y/N]: " CONFIRM
+[[ ! "$CONFIRM" =~ ^[Yy]$ ]] && echo "Aborted." && exit 0
+echo ""
+
+# ── Check if resources already exist ──────────────────────────────────────────
+ALREADY_EXISTS=()
+
+if aws sagemaker describe-endpoint-config \
+    --endpoint-config-name "$ENDPOINT_CONFIG_NAME" \
+    --region "$AWS_REGION" &>/dev/null; then
+  ALREADY_EXISTS+=("Endpoint config : $ENDPOINT_CONFIG_NAME")
+fi
+
+if aws sagemaker describe-endpoint \
+    --endpoint-name "$ENDPOINT_NAME" \
+    --region "$AWS_REGION" &>/dev/null; then
+  ALREADY_EXISTS+=("Endpoint        : $ENDPOINT_NAME")
+fi
+
+if [ ${#ALREADY_EXISTS[@]} -gt 0 ]; then
+  echo ""
+  echo "ERROR: The following resources already exist:"
+  for RES in "${ALREADY_EXISTS[@]}"; do echo "  - $RES"; done
+  echo ""
+  echo "  Delete them first: ./scripts/delete_endpoint.sh $NIM_TYPE"
+  exit 1
+fi
+
+# ── Create endpoint configuration ─────────────────────────────────────────────
+echo "→ Creating endpoint configuration '$ENDPOINT_CONFIG_NAME' ..."
+
+# ContainerStartupHealthCheckTimeoutInSeconds: how long SageMaker waits for the
+# container to pass /ping health checks before declaring deployment failed.
+# NIM downloads model weights at startup — NVIDIA docs say up to 60 minutes.
+# We default to 3600s (60 min). Raise SAGEMAKER_CONTAINER_STARTUP_TIMEOUT in
+# .env if your instance or network is slower.
+STARTUP_TIMEOUT="${SAGEMAKER_CONTAINER_STARTUP_TIMEOUT:-3600}"
+
+aws sagemaker create-endpoint-config \
+  --endpoint-config-name "$ENDPOINT_CONFIG_NAME" \
+  --production-variants "[{
+    \"VariantName\": \"primary\",
+    \"ModelName\": \"$MODEL_NAME\",
+    \"InstanceType\": \"$INSTANCE_TYPE\",
+    \"InitialInstanceCount\": $INSTANCE_COUNT,
+    \"ContainerStartupHealthCheckTimeoutInSeconds\": $STARTUP_TIMEOUT
+  }]" \
+  --region "$AWS_REGION" \
+  > /dev/null
+
+echo "  Done."
+
+# ── Deploy endpoint ───────────────────────────────────────────────────────────
+echo "→ Deploying endpoint '$ENDPOINT_NAME' ..."
+echo "  (NIM downloads model weights at startup — allow up to 60 minutes)"
+
+aws sagemaker create-endpoint \
+  --endpoint-name "$ENDPOINT_NAME" \
+  --endpoint-config-name "$ENDPOINT_CONFIG_NAME" \
+  --region "$AWS_REGION" \
+  > /dev/null
+
+# ── Wait for InService ────────────────────────────────────────────────────────
+echo ""
+echo "  Waiting for endpoint to become InService ..."
+echo "  (polling every 30 seconds — press Ctrl+C to stop waiting;"
+echo "   the deployment will continue in the background)"
+echo ""
+
+DOTS=""
+while true; do
+  STATUS=$(aws sagemaker describe-endpoint \
+    --endpoint-name "$ENDPOINT_NAME" \
+    --region "$AWS_REGION" \
+    --query 'EndpointStatus' \
+    --output text)
+
+  if [ "$STATUS" = "InService" ]; then
+    echo ""
+    echo "✓ Endpoint '$ENDPOINT_NAME' is InService."
+    echo ""
+    echo "  Console: https://${AWS_REGION}.console.aws.amazon.com/sagemaker/home?region=${AWS_REGION}#/endpoints/${ENDPOINT_NAME}"
+    echo ""
+    echo "  Next step: test the endpoint — see client/README.md for test client usage."
+    break
+  elif [ "$STATUS" = "Failed" ]; then
+    echo ""
+    FAILURE_REASON=$(aws sagemaker describe-endpoint \
+      --endpoint-name "$ENDPOINT_NAME" \
+      --region "$AWS_REGION" \
+      --query 'FailureReason' \
+      --output text)
+    echo "ERROR: Endpoint deployment failed."
+    echo "  Reason: $FAILURE_REASON"
+    echo ""
+    echo "  Check the SageMaker console for details:"
+    echo "  https://${AWS_REGION}.console.aws.amazon.com/sagemaker/home?region=${AWS_REGION}#/endpoints/${ENDPOINT_NAME}"
+    exit 1
+  else
+    DOTS="${DOTS}."
+    printf "\r  Status: %-20s %s" "$STATUS" "$DOTS"
+    sleep 30
+  fi
+done

--- a/deployment/aws-sagemaker-nvidia/scripts/create_iam.sh
+++ b/deployment/aws-sagemaker-nvidia/scripts/create_iam.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# create_iam.sh — Create the IAM resources needed to deploy Magpie TTS on SageMaker
+#
+# Creates:
+#   1. A SageMaker execution role  — used by SageMaker when running the endpoint
+#   2. A deployer IAM user         — used by you (or CI) to run the deployment scripts
+#   3. Access keys for the deployer user (printed at the end — save them!)
+#
+# Run this ONCE as an AWS admin user (or a user with IAM write permissions).
+# After running, copy the printed credentials into your .env file.
+#
+# Usage:
+#   ./scripts/create_iam.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# ── Load only AWS_REGION from .env — do NOT load credentials ─────────────────
+# This script must run with your personal admin credentials (aws configure).
+# The deployer credentials don't exist yet — they are created by this script.
+if [ -f "$ROOT_DIR/.env" ]; then
+  AWS_REGION_FROM_ENV=$(grep -E '^AWS_REGION=' "$ROOT_DIR/.env" | head -1 | cut -d= -f2)
+fi
+
+# ── Config ────────────────────────────────────────────────────────────────────
+AWS_REGION="${AWS_REGION:-${AWS_REGION_FROM_ENV:-us-west-2}}"
+DEPLOYER_USER_NAME="magpie-sagemaker-deployer"
+DEPLOYER_POLICY_NAME="MagpieSageMakerDeployPolicy"
+EXECUTION_ROLE_NAME="magpie-sagemaker-execution-role"
+
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+echo ""
+echo "AWS account : $AWS_ACCOUNT_ID"
+echo "Region      : $AWS_REGION"
+echo "Deployer    : $DEPLOYER_USER_NAME"
+echo "Exec role   : $EXECUTION_ROLE_NAME"
+echo ""
+
+# ── Confirmation safeguard ────────────────────────────────────────────────────
+echo "This script will create or modify the following IAM resources:"
+echo ""
+echo "  IAM Role : $EXECUTION_ROLE_NAME"
+echo "  IAM User : $DEPLOYER_USER_NAME"
+echo ""
+echo "In AWS Account: $AWS_ACCOUNT_ID"
+echo "Region: $AWS_REGION"
+echo ""
+
+read -r -p "Continue? [y/N]: " CONFIRM
+[[ ! "$CONFIRM" =~ ^[Yy]$ ]] && echo "Aborted." && exit 0
+
+echo ""
+echo "Proceeding with IAM setup..."
+echo ""
+
+# ── 1. SageMaker execution role ───────────────────────────────────────────────
+echo "─── Step 1: SageMaker execution role ───────────────────────────────────"
+
+TRUST_POLICY=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "Service": "sagemaker.amazonaws.com" },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+)
+
+if aws iam get-role --role-name "$EXECUTION_ROLE_NAME" &>/dev/null; then
+  echo "  Role '$EXECUTION_ROLE_NAME' already exists — skipping creation."
+else
+  aws iam create-role \
+    --role-name "$EXECUTION_ROLE_NAME" \
+    --assume-role-policy-document "$TRUST_POLICY" \
+    --description "SageMaker execution role for Magpie TTS NIM endpoint" \
+    > /dev/null
+  echo "  Created role: $EXECUTION_ROLE_NAME"
+fi
+
+# Attach managed policies to the execution role
+for POLICY_ARN in \
+  "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess" \
+  "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"; do
+  aws iam attach-role-policy \
+    --role-name "$EXECUTION_ROLE_NAME" \
+    --policy-arn "$POLICY_ARN" 2>/dev/null && \
+    echo "  Attached: $POLICY_ARN" || \
+    echo "  Already attached: $POLICY_ARN"
+done
+
+EXECUTION_ROLE_ARN="arn:aws:iam::${AWS_ACCOUNT_ID}:role/${EXECUTION_ROLE_NAME}"
+echo "  Role ARN: $EXECUTION_ROLE_ARN"
+
+# ── 2. Deployer IAM user ──────────────────────────────────────────────────────
+echo ""
+echo "─── Step 2: Deployer IAM user ──────────────────────────────────────────"
+
+if aws iam get-user --user-name "$DEPLOYER_USER_NAME" &>/dev/null; then
+  echo "  User '$DEPLOYER_USER_NAME' already exists — skipping creation."
+else
+  aws iam create-user \
+    --user-name "$DEPLOYER_USER_NAME" \
+    > /dev/null
+  echo "  Created user: $DEPLOYER_USER_NAME"
+fi
+
+# ── 3. Deployer inline policy (minimal permissions) ───────────────────────────
+echo ""
+echo "─── Step 3: Deployer permissions policy ────────────────────────────────"
+
+DEPLOY_POLICY=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ECRAuth",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ECRImagePush",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:CreateRepository",
+        "ecr:DescribeRepositories",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage"
+      ],
+      "Resource": "arn:aws:ecr:${AWS_REGION}:${AWS_ACCOUNT_ID}:repository/*"
+    },
+    {
+      "Sid": "SageMakerDeploy",
+      "Effect": "Allow",
+      "Action": [
+        "sagemaker:CreateModel",
+        "sagemaker:DescribeModel",
+        "sagemaker:DeleteModel",
+        "sagemaker:ListModels",
+        "sagemaker:CreateEndpointConfig",
+        "sagemaker:DescribeEndpointConfig",
+        "sagemaker:DeleteEndpointConfig",
+        "sagemaker:ListEndpointConfigs",
+        "sagemaker:CreateEndpoint",
+        "sagemaker:DescribeEndpoint",
+        "sagemaker:DeleteEndpoint",
+        "sagemaker:ListEndpoints",
+        "sagemaker:InvokeEndpoint"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CloudWatchLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:GetLogEvents",
+        "logs:FilterLogEvents",
+        "logs:StartQuery",
+        "logs:GetQueryResults",
+        "logs:StopQuery",
+        "logs:DeleteLogGroup"
+      ],
+      "Resource": "arn:aws:logs:${AWS_REGION}:${AWS_ACCOUNT_ID}:log-group:/aws/sagemaker/*"
+    },
+    {
+      "Sid": "PassSageMakerRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "${EXECUTION_ROLE_ARN}",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "sagemaker.amazonaws.com"
+        }
+      }
+    }
+  ]
+}
+EOF
+)
+
+aws iam put-user-policy \
+  --user-name "$DEPLOYER_USER_NAME" \
+  --policy-name "$DEPLOYER_POLICY_NAME" \
+  --policy-document "$DEPLOY_POLICY"
+echo "  Attached inline policy: $DEPLOYER_POLICY_NAME"
+
+# ── 4. Create access keys ─────────────────────────────────────────────────────
+echo ""
+echo "─── Step 4: Access keys ────────────────────────────────────────────────"
+
+# Check if user already has 2 keys (AWS limit)
+KEY_COUNT=$(aws iam list-access-keys --user-name "$DEPLOYER_USER_NAME" \
+  --query 'length(AccessKeyMetadata)' --output text)
+
+if [ "$KEY_COUNT" -ge 2 ]; then
+  echo "  WARNING: User already has 2 access keys (AWS limit)."
+  echo "  Delete an existing key in the AWS console before creating a new one:"
+  echo "  https://console.aws.amazon.com/iam/home#/users/$DEPLOYER_USER_NAME"
+else
+  KEYS=$(aws iam create-access-key --user-name "$DEPLOYER_USER_NAME")
+  ACCESS_KEY_ID=$(echo "$KEYS" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['AccessKey']['AccessKeyId'])")
+  SECRET_ACCESS_KEY=$(echo "$KEYS" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['AccessKey']['SecretAccessKey'])")
+
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  SAVE THESE — they will not be shown again."
+  echo ""
+  echo "  Add the following to your .env file:"
+  echo ""
+  echo "  AWS_ACCESS_KEY_ID=$ACCESS_KEY_ID"
+  echo "  AWS_SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY"
+  echo "  AWS_REGION=$AWS_REGION"
+  echo "  SAGEMAKER_EXECUTION_ROLE_ARN=$EXECUTION_ROLE_ARN"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+fi
+
+echo ""
+echo "✓ IAM setup complete."

--- a/deployment/aws-sagemaker-nvidia/scripts/create_model.sh
+++ b/deployment/aws-sagemaker-nvidia/scripts/create_model.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# create_model.sh — Register a NIM SageMaker wrapper image as a SageMaker Model
+#
+# Uses the SageMaker wrapper image (built by build_wrapper.sh, pushed by push_to_ecr.sh)
+# which bundles the NIM server + a FastAPI layer that translates SageMaker's interface.
+#
+# Usage:
+#   ./scripts/create_model.sh              # interactive prompt to choose NIM
+#   ./scripts/create_model.sh magpie       # Magpie TTS
+#   ./scripts/create_model.sh nemotron-asr # Nemotron ASR Streaming
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# ── Load .env ─────────────────────────────────────────────────────────────────
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+# ── Resolve NIM type ──────────────────────────────────────────────────────────
+NIM_TYPE="${1:-}"
+
+if [ -z "$NIM_TYPE" ]; then
+  echo ""
+  echo "Which NIM model would you like to register?"
+  echo ""
+  echo "  1) magpie       — Magpie TTS (text-to-speech)"
+  echo "  2) nemotron-asr — Nemotron ASR Streaming (speech-to-text)"
+  echo ""
+  read -rp "Enter choice [1/2] or name [magpie/nemotron-asr]: " NIM_CHOICE
+  echo ""
+  case "$NIM_CHOICE" in
+    1|magpie)        NIM_TYPE="magpie" ;;
+    2|nemotron-asr)  NIM_TYPE="nemotron-asr" ;;
+    *)
+      echo "ERROR: Invalid choice '$NIM_CHOICE'. Aborting."
+      exit 1
+      ;;
+  esac
+fi
+
+case "$NIM_TYPE" in
+  magpie)
+    MODEL_NAME="${SAGEMAKER_MAGPIE_MODEL_NAME:-}"
+    ECR_URI="${ECR_MAGPIE_IMAGE_URI:-}"
+    CONTAINER_HOSTNAME="magpie-tts-multilingual"
+    EXTRA_ENV_VARS=""
+    MODEL_NAME_VAR="SAGEMAKER_MAGPIE_MODEL_NAME"
+    ECR_URI_VAR="ECR_MAGPIE_IMAGE_URI  ← run scripts/push_to_ecr.sh magpie first"
+    ;;
+  nemotron-asr)
+    MODEL_NAME="${SAGEMAKER_ASR_MODEL_NAME:-}"
+    ECR_URI="${ECR_ASR_IMAGE_URI:-}"
+    CONTAINER_HOSTNAME="nemotron-asr-streaming"
+    # Nemotron ASR Streaming requires mode=str to enable streaming support
+    # and CONTAINER_ID to select the nemotron-asr-streaming model profile
+    EXTRA_ENV_VARS=",NIM_TAGS_SELECTOR=mode=str,CONTAINER_ID=nemotron-asr-streaming"
+    MODEL_NAME_VAR="SAGEMAKER_ASR_MODEL_NAME"
+    ECR_URI_VAR="ECR_ASR_IMAGE_URI  ← run scripts/push_to_ecr.sh nemotron-asr first"
+    ;;
+  *)
+    echo "ERROR: Unknown NIM type '$NIM_TYPE'."
+    echo ""
+    echo "  Usage:"
+    echo "    ./scripts/create_model.sh magpie"
+    echo "    ./scripts/create_model.sh nemotron-asr"
+    echo ""
+    exit 1
+    ;;
+esac
+
+# ── Validate required vars ────────────────────────────────────────────────────
+MISSING=()
+[ -z "${AWS_ACCESS_KEY_ID:-}" ]            && MISSING+=("AWS_ACCESS_KEY_ID")
+[ -z "${AWS_SECRET_ACCESS_KEY:-}" ]        && MISSING+=("AWS_SECRET_ACCESS_KEY")
+[ -z "${AWS_REGION:-}" ]                   && MISSING+=("AWS_REGION")
+[ -z "$ECR_URI" ]                          && MISSING+=("$ECR_URI_VAR")
+[ -z "${SAGEMAKER_EXECUTION_ROLE_ARN:-}" ] && MISSING+=("SAGEMAKER_EXECUTION_ROLE_ARN  ← run scripts/create_iam.sh first")
+[ -z "$MODEL_NAME" ]                       && MISSING+=("$MODEL_NAME_VAR")
+[ -z "${NGC_API_KEY:-}" ]                  && MISSING+=("NGC_API_KEY  ← needed by the NIM container at runtime")
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo ""
+  echo "ERROR: Missing required variables in .env:"
+  for VAR in "${MISSING[@]}"; do echo "  - $VAR"; done
+  echo ""
+  exit 1
+fi
+
+# ── Confirm ───────────────────────────────────────────────────────────────────
+NIM_HTTP_PORT="${NIM_HTTP_API_PORT:-9000}"
+NIM_GRPC_PORT="${NIM_GRPC_API_PORT:-50051}"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Creating SageMaker Model  [$NIM_TYPE]"
+echo ""
+echo " Model name   : $MODEL_NAME"
+echo " Image URI    : $ECR_URI"
+echo " Exec role    : $SAGEMAKER_EXECUTION_ROLE_ARN"
+echo " NIM HTTP port: $NIM_HTTP_PORT  (NIM's internal port, wrapper exposes 8080)"
+echo " NIM gRPC port: $NIM_GRPC_PORT"
+echo " Region       : $AWS_REGION"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+read -r -p "Continue? [y/N]: " CONFIRM
+[[ ! "$CONFIRM" =~ ^[Yy]$ ]] && echo "Aborted." && exit 0
+
+# ── Check if model already exists ─────────────────────────────────────────────
+if aws sagemaker describe-model \
+    --model-name "$MODEL_NAME" \
+    --region "$AWS_REGION" &>/dev/null; then
+  echo ""
+  echo "ERROR: Model '$MODEL_NAME' already exists."
+  echo "  Delete it first: ./scripts/delete_model.sh $NIM_TYPE"
+  exit 1
+fi
+
+# ── Create the model ──────────────────────────────────────────────────────────
+echo ""
+echo "→ Creating model '$MODEL_NAME' ..."
+
+# Environment variables passed to the wrapper container at runtime:
+#   NGC_API_KEY          — NIM downloads model weights using this key
+#   NIM_HTTP_API_PORT    — NIM's internal HTTP port (default 9000)
+#   NIM_GRPC_API_PORT    — NIM's gRPC port (default 50051)
+#   NIM_TAGS_SELECTOR    — (nemotron-asr only) selects the streaming model profile
+#   CONTAINER_ID         — (nemotron-asr only) selects the nemotron-asr-streaming model
+#   TORCH_CUDA_ARCH_LIST — (optional) restricts PyTorch JIT to the instance's GPU arch
+ENV_VARS="NGC_API_KEY=${NGC_API_KEY},NIM_HTTP_API_PORT=${NIM_HTTP_PORT},NIM_GRPC_API_PORT=${NIM_GRPC_PORT}${EXTRA_ENV_VARS}"
+if [ -n "${TORCH_CUDA_ARCH_LIST:-}" ]; then
+  ENV_VARS="${ENV_VARS},TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}"
+fi
+
+aws sagemaker create-model \
+  --model-name "$MODEL_NAME" \
+  --primary-container "Image=${ECR_URI},ContainerHostname=${CONTAINER_HOSTNAME},Environment={${ENV_VARS}}" \
+  --execution-role-arn "$SAGEMAKER_EXECUTION_ROLE_ARN" \
+  --region "$AWS_REGION" \
+  > /dev/null
+
+echo ""
+echo "✓ Model '$MODEL_NAME' created."
+echo ""
+echo "  Next step: create and deploy the endpoint:"
+echo "    ./scripts/create_endpoint.sh $NIM_TYPE"

--- a/deployment/aws-sagemaker-nvidia/scripts/delete_endpoint.sh
+++ b/deployment/aws-sagemaker-nvidia/scripts/delete_endpoint.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# delete_endpoint.sh — Delete a SageMaker endpoint and its endpoint configuration
+#
+# Also deletes the endpoint configuration, since it is tied to this endpoint
+# and has no use once the endpoint is gone.
+#
+# Usage:
+#   ./scripts/delete_endpoint.sh                        # interactive prompt to choose NIM
+#   ./scripts/delete_endpoint.sh magpie                 # uses SAGEMAKER_MAGPIE_ENDPOINT_NAME from .env
+#   ./scripts/delete_endpoint.sh nemotron-asr           # uses SAGEMAKER_ASR_ENDPOINT_NAME from .env
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# ── Load .env ─────────────────────────────────────────────────────────────────
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+# ── Resolve NIM type ──────────────────────────────────────────────────────────
+NIM_TYPE="${1:-}"
+
+if [ -z "$NIM_TYPE" ]; then
+  echo ""
+  echo "Which NIM endpoint would you like to delete?"
+  echo ""
+  echo "  1) magpie       — Magpie TTS (text-to-speech)"
+  echo "  2) nemotron-asr — Nemotron ASR Streaming (speech-to-text)"
+  echo ""
+  read -rp "Enter choice [1/2] or name [magpie/nemotron-asr]: " NIM_CHOICE
+  echo ""
+  case "$NIM_CHOICE" in
+    1|magpie)        NIM_TYPE="magpie" ;;
+    2|nemotron-asr)  NIM_TYPE="nemotron-asr" ;;
+    *)
+      echo "ERROR: Invalid choice '$NIM_CHOICE'. Aborting."
+      exit 1
+      ;;
+  esac
+fi
+
+case "$NIM_TYPE" in
+  magpie)
+    ENDPOINT_NAME="${SAGEMAKER_MAGPIE_ENDPOINT_NAME:-}"
+    ENDPOINT_CONFIG_NAME="${SAGEMAKER_MAGPIE_ENDPOINT_CONFIG_NAME:-}"
+    ;;
+  nemotron-asr)
+    ENDPOINT_NAME="${SAGEMAKER_ASR_ENDPOINT_NAME:-}"
+    ENDPOINT_CONFIG_NAME="${SAGEMAKER_ASR_ENDPOINT_CONFIG_NAME:-}"
+    ;;
+  *)
+    echo "ERROR: Unknown NIM type '$NIM_TYPE'."
+    echo ""
+    echo "  Usage:"
+    echo "    ./scripts/delete_endpoint.sh magpie"
+    echo "    ./scripts/delete_endpoint.sh nemotron-asr"
+    echo ""
+    exit 1
+    ;;
+esac
+
+AWS_REGION="${AWS_REGION:-us-west-2}"
+
+if [ -z "$ENDPOINT_NAME" ]; then
+  echo ""
+  echo "ERROR: No endpoint name found."
+  echo "  Set the appropriate variable in .env:"
+  echo "    magpie       → SAGEMAKER_MAGPIE_ENDPOINT_NAME"
+  echo "    nemotron-asr → SAGEMAKER_ASR_ENDPOINT_NAME"
+  echo ""
+  exit 1
+fi
+
+# ── Check what actually exists ────────────────────────────────────────────────
+ENDPOINT_EXISTS=false
+CONFIG_EXISTS=false
+
+if aws sagemaker describe-endpoint \
+    --endpoint-name "$ENDPOINT_NAME" \
+    --region "$AWS_REGION" &>/dev/null; then
+  ENDPOINT_EXISTS=true
+  STATUS=$(aws sagemaker describe-endpoint \
+    --endpoint-name "$ENDPOINT_NAME" \
+    --region "$AWS_REGION" \
+    --query 'EndpointStatus' \
+    --output text)
+fi
+
+if [ -n "$ENDPOINT_CONFIG_NAME" ] && aws sagemaker describe-endpoint-config \
+    --endpoint-config-name "$ENDPOINT_CONFIG_NAME" \
+    --region "$AWS_REGION" &>/dev/null; then
+  CONFIG_EXISTS=true
+fi
+
+LOG_GROUP="/aws/sagemaker/Endpoints/${ENDPOINT_NAME}"
+LOGS_EXIST=false
+FOUND_LOG=$(aws logs describe-log-groups \
+    --log-group-name-prefix "$LOG_GROUP" \
+    --region "$AWS_REGION" \
+    --query "logGroups[?logGroupName=='${LOG_GROUP}'].logGroupName | [0]" \
+    --output text 2>/dev/null) || true
+if [ "$FOUND_LOG" = "$LOG_GROUP" ]; then
+  LOGS_EXIST=true
+fi
+
+if ! $ENDPOINT_EXISTS && ! $CONFIG_EXISTS && ! $LOGS_EXIST; then
+  echo ""
+  echo "ERROR: Neither endpoint '$ENDPOINT_NAME' nor config '$ENDPOINT_CONFIG_NAME' nor its logs found in region '$AWS_REGION'."
+  echo "  Run ./scripts/list_endpoints.sh to see available endpoints."
+  echo ""
+  exit 1
+fi
+
+# ── Confirm ───────────────────────────────────────────────────────────────────
+DELETE_LOGS=false
+if $LOGS_EXIST; then
+  read -r -p "Delete CloudWatch logs for this endpoint ($LOG_GROUP)? [y/N]: " CONFIRM_LOGS
+  [[ "$CONFIRM_LOGS" =~ ^[Yy]$ ]] && DELETE_LOGS=true
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Deleting SageMaker Endpoint  [$NIM_TYPE]"
+echo ""
+if $ENDPOINT_EXISTS; then
+  echo " Endpoint       : $ENDPOINT_NAME  (currently: $STATUS)"
+else
+  echo " Endpoint       : $ENDPOINT_NAME  (not found — skipping)"
+fi
+if [ -n "$ENDPOINT_CONFIG_NAME" ]; then
+  if $CONFIG_EXISTS; then
+    echo " Endpoint config: $ENDPOINT_CONFIG_NAME  (will be deleted)"
+  else
+    echo " Endpoint config: $ENDPOINT_CONFIG_NAME  (not found — skipping)"
+  fi
+fi
+if $LOGS_EXIST; then
+  if $DELETE_LOGS; then
+    echo " Log group      : $LOG_GROUP  (will be deleted)"
+  else
+    echo " Log group      : $LOG_GROUP  (skipping)"
+  fi
+fi
+echo " Region         : $AWS_REGION"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+read -r -p "Continue? [y/N]: " CONFIRM
+[[ ! "$CONFIRM" =~ ^[Yy]$ ]] && echo "Aborted." && exit 0
+echo ""
+
+# ── Delete endpoint ───────────────────────────────────────────────────────────
+if $ENDPOINT_EXISTS; then
+  echo "→ Deleting endpoint '$ENDPOINT_NAME' ..."
+  aws sagemaker delete-endpoint \
+    --endpoint-name "$ENDPOINT_NAME" \
+    --region "$AWS_REGION"
+  echo "  Done."
+fi
+
+# ── Delete endpoint configuration ─────────────────────────────────────────────
+if $CONFIG_EXISTS; then
+  echo "→ Deleting endpoint configuration '$ENDPOINT_CONFIG_NAME' ..."
+  aws sagemaker delete-endpoint-config \
+    --endpoint-config-name "$ENDPOINT_CONFIG_NAME" \
+    --region "$AWS_REGION"
+  echo "  Done."
+fi
+
+# ── Delete CloudWatch log group ───────────────────────────────────────────────
+if $DELETE_LOGS; then
+  echo "→ Deleting CloudWatch log group '$LOG_GROUP' ..."
+  aws logs delete-log-group \
+    --log-group-name "$LOG_GROUP" \
+    --region "$AWS_REGION"
+  echo "  Done."
+fi
+
+echo ""
+echo "✓ Cleanup complete."
+echo "  Note: the SageMaker Model and ECR image are NOT deleted."
+echo "  To delete the model: ./scripts/delete_model.sh $NIM_TYPE"

--- a/deployment/aws-sagemaker-nvidia/scripts/delete_model.sh
+++ b/deployment/aws-sagemaker-nvidia/scripts/delete_model.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# delete_model.sh — Delete a SageMaker Model
+#
+# Note: you must delete (or update) any endpoints using this model first.
+# Run ./scripts/delete_endpoint.sh before this script.
+#
+# Usage:
+#   ./scripts/delete_model.sh              # interactive prompt to choose NIM
+#   ./scripts/delete_model.sh magpie       # uses SAGEMAKER_MAGPIE_MODEL_NAME from .env
+#   ./scripts/delete_model.sh nemotron-asr # uses SAGEMAKER_ASR_MODEL_NAME from .env
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# ── Load .env ─────────────────────────────────────────────────────────────────
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+# ── Resolve NIM type ──────────────────────────────────────────────────────────
+NIM_TYPE="${1:-}"
+
+if [ -z "$NIM_TYPE" ]; then
+  echo ""
+  echo "Which NIM model would you like to delete?"
+  echo ""
+  echo "  1) magpie       — Magpie TTS (text-to-speech)"
+  echo "  2) nemotron-asr — Nemotron ASR Streaming (speech-to-text)"
+  echo ""
+  read -rp "Enter choice [1/2] or name [magpie/nemotron-asr]: " NIM_CHOICE
+  echo ""
+  case "$NIM_CHOICE" in
+    1|magpie)        NIM_TYPE="magpie" ;;
+    2|nemotron-asr)  NIM_TYPE="nemotron-asr" ;;
+    *)
+      echo "ERROR: Invalid choice '$NIM_CHOICE'. Aborting."
+      exit 1
+      ;;
+  esac
+fi
+
+case "$NIM_TYPE" in
+  magpie)
+    MODEL_NAME="${SAGEMAKER_MAGPIE_MODEL_NAME:-}"
+    ;;
+  nemotron-asr)
+    MODEL_NAME="${SAGEMAKER_ASR_MODEL_NAME:-}"
+    ;;
+  *)
+    echo "ERROR: Unknown NIM type '$NIM_TYPE'."
+    echo ""
+    echo "  Usage:"
+    echo "    ./scripts/delete_model.sh magpie"
+    echo "    ./scripts/delete_model.sh nemotron-asr"
+    echo ""
+    exit 1
+    ;;
+esac
+
+AWS_REGION="${AWS_REGION:-us-west-2}"
+
+if [ -z "$MODEL_NAME" ]; then
+  echo ""
+  echo "ERROR: No model name found."
+  echo "  Set the appropriate variable in .env:"
+  echo "    magpie       → SAGEMAKER_MAGPIE_MODEL_NAME"
+  echo "    nemotron-asr → SAGEMAKER_ASR_MODEL_NAME"
+  echo ""
+  exit 1
+fi
+
+# ── Check the model exists ────────────────────────────────────────────────────
+if ! aws sagemaker describe-model \
+      --model-name "$MODEL_NAME" \
+      --region "$AWS_REGION" &>/dev/null; then
+  echo ""
+  echo "ERROR: Model '$MODEL_NAME' not found in region '$AWS_REGION'."
+  echo ""
+  exit 1
+fi
+
+# ── Confirm ───────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Deleting SageMaker Model  [$NIM_TYPE]"
+echo ""
+echo " Model   : $MODEL_NAME"
+echo " Region  : $AWS_REGION"
+echo ""
+echo " NOTE: The ECR image will NOT be deleted."
+echo "       Make sure no active endpoints are using this model."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+read -r -p "Continue? [y/N]: " CONFIRM
+[[ ! "$CONFIRM" =~ ^[Yy]$ ]] && echo "Aborted." && exit 0
+echo ""
+
+# ── Delete model ──────────────────────────────────────────────────────────────
+echo "→ Deleting model '$MODEL_NAME' ..."
+aws sagemaker delete-model \
+  --model-name "$MODEL_NAME" \
+  --region "$AWS_REGION"
+
+echo ""
+echo "✓ Model '$MODEL_NAME' deleted."

--- a/deployment/aws-sagemaker-nvidia/scripts/fix-ruff.sh
+++ b/deployment/aws-sagemaker-nvidia/scripts/fix-ruff.sh
@@ -1,0 +1,10 @@
+
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+echo "Running ruff format..."
+uv run ruff format "$PROJECT_ROOT"
+echo "Running ruff check..."
+uv run ruff check --fix "$PROJECT_ROOT"

--- a/deployment/aws-sagemaker-nvidia/scripts/list_endpoints.sh
+++ b/deployment/aws-sagemaker-nvidia/scripts/list_endpoints.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# list_endpoints.sh — List all SageMaker endpoints and their current status
+#
+# Usage:
+#   ./scripts/list_endpoints.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# ── Load .env ─────────────────────────────────────────────────────────────────
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+AWS_REGION="${AWS_REGION:-us-west-2}"
+
+# ── List endpoints ────────────────────────────────────────────────────────────
+echo ""
+echo "SageMaker Endpoints — region: $AWS_REGION"
+echo ""
+
+ENDPOINTS=$(aws sagemaker list-endpoints \
+  --region "$AWS_REGION" \
+  --query 'Endpoints[*].EndpointName' \
+  --output text 2>/dev/null || true)
+
+if [ -z "$ENDPOINTS" ]; then
+  echo "  No endpoints found."
+  echo ""
+  echo "  Console: https://${AWS_REGION}.console.aws.amazon.com/sagemaker/home?region=${AWS_REGION}#/endpoints"
+  echo ""
+  exit 0
+fi
+
+# ── Show status for each endpoint ─────────────────────────────────────────────
+for NAME in $ENDPOINTS; do
+  INFO=$(aws sagemaker describe-endpoint \
+    --endpoint-name "$NAME" \
+    --region "$AWS_REGION" \
+    --query '{Status:EndpointStatus, Reason:FailureReason, Created:CreationTime}' \
+    --output json 2>/dev/null)
+
+  STATUS=$(echo "$INFO" | python3 -c "import sys,json; print(json.load(sys.stdin)['Status'])")
+  CREATED=$(echo "$INFO" | python3 -c "import sys,json; print(json.load(sys.stdin)['Created'][:10])")
+
+  case "$STATUS" in
+    InService)  ICON="✓" ;;
+    Creating)   ICON="⏳" ;;
+    Updating)   ICON="⏳" ;;
+    Failed)     ICON="✗" ;;
+    Deleting)   ICON="🗑" ;;
+    *)          ICON=" " ;;
+  esac
+
+  printf "  %s  %-40s  %-12s  created %s\n" "$ICON" "$NAME" "$STATUS" "$CREATED"
+
+  if [ "$STATUS" = "Failed" ]; then
+    REASON=$(echo "$INFO" | python3 -c "import sys,json; print(json.load(sys.stdin).get('FailureReason') or 'unknown')")
+    printf "     Reason: %s\n" "$REASON"
+    printf "     Logs:   ./scripts/logs_endpoint.sh %s\n" "$NAME"
+  fi
+done
+
+echo ""
+echo "  Console: https://${AWS_REGION}.console.aws.amazon.com/sagemaker/home?region=${AWS_REGION}#/endpoints"
+echo ""

--- a/deployment/aws-sagemaker-nvidia/scripts/logs_endpoint.sh
+++ b/deployment/aws-sagemaker-nvidia/scripts/logs_endpoint.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# logs_endpoint.sh — Stream or tail CloudWatch logs for a SageMaker endpoint
+#
+# SageMaker writes all container stdout/stderr to CloudWatch under:
+#   /aws/sagemaker/Endpoints/<endpoint-name>/<instance-id>/...
+#
+# Usage:
+#   ./scripts/logs_endpoint.sh              # interactive prompt to choose NIM
+#   ./scripts/logs_endpoint.sh magpie       # uses SAGEMAKER_MAGPIE_ENDPOINT_NAME from .env
+#   ./scripts/logs_endpoint.sh nemotron-asr # uses SAGEMAKER_ASR_ENDPOINT_NAME from .env
+#   ./scripts/logs_endpoint.sh magpie --no-follow       # print recent logs and exit
+#   ./scripts/logs_endpoint.sh nemotron-asr --no-follow # print recent logs and exit
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# ── Load .env ─────────────────────────────────────────────────────────────────
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+NIM_TYPE=""
+FOLLOW=true
+
+for ARG in "$@"; do
+  case "$ARG" in
+    --no-follow)   FOLLOW=false ;;
+    --follow)      FOLLOW=true  ;;
+    magpie)        NIM_TYPE="magpie" ;;
+    nemotron-asr)  NIM_TYPE="nemotron-asr" ;;
+    -*)            echo "Unknown option: $ARG"; exit 1 ;;
+    *)             echo "Unknown argument: $ARG"; exit 1 ;;
+  esac
+done
+
+# ── Resolve NIM type ──────────────────────────────────────────────────────────
+if [ -z "$NIM_TYPE" ]; then
+  echo ""
+  echo "Which NIM endpoint logs would you like to view?"
+  echo ""
+  echo "  1) magpie       — Magpie TTS (text-to-speech)"
+  echo "  2) nemotron-asr — Nemotron ASR Streaming (speech-to-text)"
+  echo ""
+  read -rp "Enter choice [1/2] or name [magpie/nemotron-asr]: " NIM_CHOICE
+  echo ""
+  case "$NIM_CHOICE" in
+    1|magpie)        NIM_TYPE="magpie" ;;
+    2|nemotron-asr)  NIM_TYPE="nemotron-asr" ;;
+    *)
+      echo "ERROR: Invalid choice '$NIM_CHOICE'. Aborting."
+      exit 1
+      ;;
+  esac
+fi
+
+case "$NIM_TYPE" in
+  magpie)
+    ENDPOINT_NAME="${SAGEMAKER_MAGPIE_ENDPOINT_NAME:-}"
+    ;;
+  nemotron-asr)
+    ENDPOINT_NAME="${SAGEMAKER_ASR_ENDPOINT_NAME:-}"
+    ;;
+  *)
+    echo "ERROR: Unknown NIM type '$NIM_TYPE'."
+    exit 1
+    ;;
+esac
+
+if [ -z "$ENDPOINT_NAME" ]; then
+  echo ""
+  echo "ERROR: No endpoint name found."
+  echo "  Set the appropriate variable in .env:"
+  echo "    magpie       → SAGEMAKER_MAGPIE_ENDPOINT_NAME"
+  echo "    nemotron-asr → SAGEMAKER_ASR_ENDPOINT_NAME"
+  echo ""
+  exit 1
+fi
+
+REGION="${AWS_REGION:-us-west-2}"
+LOG_GROUP="/aws/sagemaker/Endpoints/${ENDPOINT_NAME}"
+
+# ── Validate required vars ────────────────────────────────────────────────────
+MISSING=()
+[ -z "${AWS_ACCESS_KEY_ID:-}" ]     && MISSING+=("AWS_ACCESS_KEY_ID")
+[ -z "${AWS_SECRET_ACCESS_KEY:-}" ] && MISSING+=("AWS_SECRET_ACCESS_KEY")
+[ -z "${AWS_REGION:-}" ]            && MISSING+=("AWS_REGION")
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo ""
+  echo "ERROR: Missing required environment variables:"
+  for VAR in "${MISSING[@]}"; do echo "  - $VAR"; done
+  echo ""
+  exit 1
+fi
+
+# ── Check endpoint exists ─────────────────────────────────────────────────────
+echo ""
+if ! aws sagemaker describe-endpoint \
+    --endpoint-name "$ENDPOINT_NAME" \
+    --region "$REGION" &>/dev/null; then
+  echo "ERROR: Endpoint '$ENDPOINT_NAME' not found in region $REGION."
+  echo "  Run ./scripts/list_endpoints.sh to see available endpoints."
+  exit 1
+fi
+
+ENDPOINT_STATUS=$(aws sagemaker describe-endpoint \
+  --endpoint-name "$ENDPOINT_NAME" \
+  --region "$REGION" \
+  --query 'EndpointStatus' \
+  --output text)
+
+# ── For failed endpoints: always print, never follow ──────────────────────────
+if [ "$ENDPOINT_STATUS" = "Failed" ]; then
+  FOLLOW=false
+fi
+
+# ── Encode log group name for CloudWatch console URL ──────────────────────────
+LOG_GROUP_ENCODED=$(echo "$LOG_GROUP" | sed 's|/|%2F|g')
+CW_URL="https://${REGION}.console.aws.amazon.com/cloudwatch/home?region=${REGION}#logsV2:log-groups/log-group/${LOG_GROUP_ENCODED}"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " SageMaker Endpoint Logs  [$NIM_TYPE]"
+echo ""
+echo " Endpoint  : $ENDPOINT_NAME  ($ENDPOINT_STATUS)"
+echo " Log group : $LOG_GROUP"
+echo " Console   : $CW_URL"
+echo " Region    : $REGION"
+if $FOLLOW; then
+  echo " Mode      : follow  (Ctrl+C to stop)"
+else
+  echo " Mode      : recent logs (pass nothing or --follow to tail live)"
+fi
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# ── Show SageMaker failure reason if endpoint is failed ───────────────────────
+if [ "$ENDPOINT_STATUS" = "Failed" ]; then
+  FAILURE_REASON=$(aws sagemaker describe-endpoint \
+    --endpoint-name "$ENDPOINT_NAME" \
+    --region "$REGION" \
+    --query 'FailureReason' \
+    --output text)
+  echo "  SageMaker failure reason: $FAILURE_REASON"
+  echo ""
+fi
+
+# ── Stream logs ───────────────────────────────────────────────────────────────
+# Failed endpoints: use a 24h window so logs aren't missed if deployment was slow.
+# Live endpoints: 1h is enough for recent activity.
+if [ "$ENDPOINT_STATUS" = "Failed" ]; then
+  SINCE="24h"
+else
+  SINCE="1h"
+fi
+
+TAIL_ARGS=(
+  "$LOG_GROUP"
+  --since "$SINCE"
+  --format short
+  --region "$REGION"
+)
+$FOLLOW && TAIL_ARGS+=(--follow)
+
+if ! aws logs tail "${TAIL_ARGS[@]}"; then
+  echo ""
+  echo "  Could not read logs from CloudWatch."
+  echo ""
+  if [ "$ENDPOINT_STATUS" = "Failed" ]; then
+    echo "  The log group may not exist — the container may never have started."
+    echo "  This usually means an image pull failure or IAM permission issue."
+    echo "  Verify:"
+    echo "    - The ECR image URI is correct (run ./scripts/push_to_ecr.sh $NIM_TYPE)"
+    echo "    - The execution role has ecr:GetAuthorizationToken and ecr:BatchGetImage"
+  else
+    echo "  If the endpoint is still deploying, wait a few minutes and try again."
+  fi
+  echo ""
+  echo "  Open CloudWatch directly: $CW_URL"
+fi

--- a/deployment/aws-sagemaker-nvidia/scripts/pull_nim.sh
+++ b/deployment/aws-sagemaker-nvidia/scripts/pull_nim.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# pull_nim.sh — Pull a NIM container from NVIDIA NGC
+#
+# Usage:
+#   ./scripts/pull_nim.sh                     # interactive prompt to choose NIM
+#   ./scripts/pull_nim.sh magpie              # pulls Magpie TTS :latest
+#   ./scripts/pull_nim.sh magpie 1.7.0        # pulls a specific Magpie TTS tag
+#   ./scripts/pull_nim.sh nemotron-asr        # pulls Nemotron ASR Streaming :latest
+#   ./scripts/pull_nim.sh nemotron-asr latest # pulls a specific Nemotron ASR tag
+#
+# Requires NGC_API_KEY to be set in .env or exported in the shell.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# ── Load .env if present ─────────────────────────────────────────────────────
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+# ── Resolve NIM type ──────────────────────────────────────────────────────────
+NIM_TYPE="${1:-}"
+
+if [ -z "$NIM_TYPE" ]; then
+  echo ""
+  echo "Which NIM would you like to pull?"
+  echo ""
+  echo "  1) magpie       — Magpie TTS (text-to-speech)"
+  echo "  2) nemotron-asr — Nemotron ASR Streaming (speech-to-text)"
+  echo ""
+  read -rp "Enter choice [1/2] or name [magpie/nemotron-asr]: " NIM_CHOICE
+  echo ""
+  case "$NIM_CHOICE" in
+    1|magpie)        NIM_TYPE="magpie" ;;
+    2|nemotron-asr)  NIM_TYPE="nemotron-asr" ;;
+    *)
+      echo "ERROR: Invalid choice '$NIM_CHOICE'. Aborting."
+      exit 1
+      ;;
+  esac
+fi
+
+case "$NIM_TYPE" in
+  magpie)
+    IMAGE_NAME="nvcr.io/nim/nvidia/magpie-tts-multilingual"
+    TAG="${2:-${MAGPIE_IMAGE_TAG:-latest}}"
+    NGC_DEPLOY_URL="https://build.nvidia.com/nvidia/magpie-tts-multilingual/deploy"
+    NGC_TAGS_URL="https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/magpie-tts-multilingual/tags?version=latest"
+    ;;
+  nemotron-asr)
+    IMAGE_NAME="nvcr.io/nim/nvidia/nemotron-asr-streaming"
+    TAG="${2:-${NEMOTRON_ASR_IMAGE_TAG:-latest}}"
+    NGC_DEPLOY_URL="https://build.nvidia.com/nvidia/nemotron-asr-streaming/deploy"
+    NGC_TAGS_URL="https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/nemotron-asr-streaming/tags?version=latest"
+    ;;
+  *)
+    echo "ERROR: Unknown NIM type '$NIM_TYPE'."
+    echo ""
+    echo "  Usage:"
+    echo "    ./scripts/pull_nim.sh magpie [tag]"
+    echo "    ./scripts/pull_nim.sh nemotron-asr [tag]"
+    echo ""
+    exit 1
+    ;;
+esac
+
+FULL_IMAGE="$IMAGE_NAME:$TAG"
+
+# SageMaker GPU instances run linux/amd64. Always pull that platform explicitly
+# so the image is correct regardless of the host machine (e.g. Apple Silicon).
+PLATFORM="linux/amd64"
+
+# ── Validate NGC_API_KEY ──────────────────────────────────────────────────────
+if [ -z "${NGC_API_KEY:-}" ]; then
+  echo ""
+  echo "ERROR: NGC_API_KEY is not set."
+  echo ""
+  echo "  Set it in your .env file:"
+  echo "    NGC_API_KEY=<your_key>"
+  echo ""
+  echo "  To generate an API key:"
+  echo "    1. Visit $NGC_DEPLOY_URL"
+  echo "    2. Click 'Get API Key' and follow the steps."
+  echo ""
+  echo "  To see all available image versions (tags):"
+  echo "    $NGC_TAGS_URL"
+  echo ""
+  exit 1
+fi
+
+# ── Login to NVIDIA NGC ───────────────────────────────────────────────────────
+echo "→ Logging in to nvcr.io ..."
+# Username must be the literal string '$oauthtoken' (not a shell variable)
+echo "$NGC_API_KEY" | docker login nvcr.io --username '$oauthtoken' --password-stdin
+
+# ── Pull the image ────────────────────────────────────────────────────────────
+echo "→ Pulling $FULL_IMAGE (platform: $PLATFORM) ..."
+if ! docker pull --platform "$PLATFORM" "$FULL_IMAGE"; then
+  echo ""
+  echo "ERROR: Failed to pull $FULL_IMAGE"
+  echo ""
+  echo "  Possible causes:"
+  echo "    - Your NGC_API_KEY is invalid or expired."
+  echo "    - Tag '$TAG' does not exist."
+  echo ""
+  echo "  To rotate your API key or check your account:"
+  echo "    $NGC_DEPLOY_URL"
+  echo ""
+  echo "  To list all available tags:"
+  echo "    $NGC_TAGS_URL"
+  echo ""
+  exit 1
+fi
+
+echo ""
+echo "✓ Successfully pulled: $FULL_IMAGE ($PLATFORM)"

--- a/deployment/aws-sagemaker-nvidia/scripts/push_to_ecr.sh
+++ b/deployment/aws-sagemaker-nvidia/scripts/push_to_ecr.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# push_to_ecr.sh — Push a SageMaker wrapper image to AWS ECR
+#
+# This is the only image SageMaker needs. The raw NIM image does not need to
+# be in ECR — it is only used locally during the wrapper build.
+#
+# Prerequisites:
+#   ./scripts/pull_nim.sh       → NIM image must be present locally
+#   ./scripts/build_wrapper.sh  → wrapper image must be built locally
+#
+# Usage:
+#   ./scripts/push_to_ecr.sh                    # interactive prompt to choose NIM
+#   ./scripts/push_to_ecr.sh magpie             # Magpie TTS, uses MAGPIE_IMAGE_TAG or 'latest'
+#   ./scripts/push_to_ecr.sh magpie 1.7.0       # Magpie TTS, specific tag
+#   ./scripts/push_to_ecr.sh nemotron-asr       # Nemotron ASR, uses NEMOTRON_ASR_IMAGE_TAG or 'latest'
+#   ./scripts/push_to_ecr.sh nemotron-asr latest # Nemotron ASR, specific tag
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# ── Load .env ─────────────────────────────────────────────────────────────────
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+# ── Validate required vars ────────────────────────────────────────────────────
+MISSING=()
+[ -z "${AWS_ACCESS_KEY_ID:-}" ]     && MISSING+=("AWS_ACCESS_KEY_ID")
+[ -z "${AWS_SECRET_ACCESS_KEY:-}" ] && MISSING+=("AWS_SECRET_ACCESS_KEY")
+[ -z "${AWS_REGION:-}" ]            && MISSING+=("AWS_REGION")
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo ""
+  echo "ERROR: Missing required environment variables:"
+  for VAR in "${MISSING[@]}"; do echo "  - $VAR"; done
+  echo ""
+  echo "  Copy env.example to .env and fill in the values."
+  echo "  If you haven't created the deployer user yet, run: ./scripts/create_iam.sh"
+  echo ""
+  exit 1
+fi
+
+# ── Resolve NIM type ──────────────────────────────────────────────────────────
+NIM_TYPE="${1:-}"
+
+if [ -z "$NIM_TYPE" ]; then
+  echo ""
+  echo "Which NIM wrapper would you like to push to ECR?"
+  echo ""
+  echo "  1) magpie       — Magpie TTS (text-to-speech)"
+  echo "  2) nemotron-asr — Nemotron ASR Streaming (speech-to-text)"
+  echo ""
+  read -rp "Enter choice [1/2] or name [magpie/nemotron-asr]: " NIM_CHOICE
+  echo ""
+  case "$NIM_CHOICE" in
+    1|magpie)        NIM_TYPE="magpie" ;;
+    2|nemotron-asr)  NIM_TYPE="nemotron-asr" ;;
+    *)
+      echo "ERROR: Invalid choice '$NIM_CHOICE'. Aborting."
+      exit 1
+      ;;
+  esac
+fi
+
+case "$NIM_TYPE" in
+  magpie)
+    TAG="${2:-${MAGPIE_IMAGE_TAG:-latest}}"
+    WRAPPER_REPO="${ECR_MAGPIE_WRAPPER_REPO_NAME:-magpie-tts-sagemaker}"
+    BUILD_HINT="./scripts/build_wrapper.sh magpie $TAG"
+    ECR_URI_VAR="ECR_MAGPIE_IMAGE_URI"
+    ;;
+  nemotron-asr)
+    TAG="${2:-${NEMOTRON_ASR_IMAGE_TAG:-latest}}"
+    WRAPPER_REPO="${ECR_ASR_WRAPPER_REPO_NAME:-nemotron-asr-sagemaker}"
+    BUILD_HINT="./scripts/build_wrapper.sh nemotron-asr $TAG"
+    ECR_URI_VAR="ECR_ASR_IMAGE_URI"
+    ;;
+  *)
+    echo "ERROR: Unknown NIM type '$NIM_TYPE'."
+    echo ""
+    echo "  Usage:"
+    echo "    ./scripts/push_to_ecr.sh magpie [tag]"
+    echo "    ./scripts/push_to_ecr.sh nemotron-asr [tag]"
+    echo ""
+    exit 1
+    ;;
+esac
+
+WRAPPER_SOURCE_IMAGE="$WRAPPER_REPO:$TAG"
+
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+ECR_REGISTRY="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
+WRAPPER_ECR_IMAGE="$ECR_REGISTRY/$WRAPPER_REPO:$TAG"
+
+# ── Verify wrapper image exists locally ───────────────────────────────────────
+if ! docker image inspect "$WRAPPER_SOURCE_IMAGE" &>/dev/null; then
+  echo ""
+  echo "ERROR: Wrapper image '$WRAPPER_SOURCE_IMAGE' not found locally."
+  echo "  Run: $BUILD_HINT"
+  exit 1
+fi
+
+# ── Confirm ───────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Pushing wrapper image to AWS ECR"
+echo ""
+echo " AWS Account : $AWS_ACCOUNT_ID"
+echo " Region      : $AWS_REGION"
+echo " Source      : $WRAPPER_SOURCE_IMAGE"
+echo " Destination : $WRAPPER_ECR_IMAGE"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+read -r -p "Continue? [y/N]: " CONFIRM
+[[ ! "$CONFIRM" =~ ^[Yy]$ ]] && echo "Cancelled." && exit 0
+
+# ── Authenticate Docker to ECR ────────────────────────────────────────────────
+echo ""
+echo "→ Authenticating Docker to ECR ..."
+aws ecr get-login-password --region "$AWS_REGION" \
+  | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+
+# ── Create ECR repository if it doesn't exist ─────────────────────────────────
+if ! aws ecr describe-repositories \
+      --repository-names "$WRAPPER_REPO" \
+      --region "$AWS_REGION" &>/dev/null; then
+  aws ecr create-repository \
+    --repository-name "$WRAPPER_REPO" \
+    --region "$AWS_REGION" \
+    > /dev/null
+  echo "  Created ECR repository: $WRAPPER_REPO"
+fi
+
+# ── Tag and push ──────────────────────────────────────────────────────────────
+echo "→ Pushing wrapper image ..."
+echo "  (First push uploads all NIM layers — this will take a while.)"
+echo "  (Subsequent pushes are fast — only wrapper changes are uploaded.)"
+echo ""
+docker tag "$WRAPPER_SOURCE_IMAGE" "$WRAPPER_ECR_IMAGE"
+docker push "$WRAPPER_ECR_IMAGE"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " Add this to your .env file:"
+echo ""
+echo "   $ECR_URI_VAR=$WRAPPER_ECR_IMAGE"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary

A practical guide and quickstart for deploying NVIDIA speech AI models (Magpie TTS and Nemotron ASR) to AWS SageMaker, and integrating them with Pipecat for real-time voice applications.
  
- Adds a complete deployment example for NVIDIA speech AI models (Magpie TTS and Nemotron ASR) on AWS SageMaker
 Includes two Pipecat bot implementations for real-time voice:
  - `pipecat-bot-http.py` — HTTP-based bot using SageMaker for TTS synthesis
  - `pipecat-bot-ws.py` — WebSocket-based bot using SageMaker for both STT (Nemotron ASR) and TTS (Magpie) via bidirectional streaming
- Provides FastAPI SageMaker wrapper containers for both Magpie TTS and Nemotron ASR to bridge NVIDIA NIM APIs with the SageMaker inference protocol
- Includes automation scripts for the full deployment lifecycle: pulling NIM containers, building/pushing wrapper images to ECR, creating SageMaker models and endpoints, monitoring logs, and teardown
- Covers infrastructure setup (IAM roles, ECR repos) and observability tooling in a comprehensive `DEPLOYMENT.md` guide
- Adds test scripts for validating HTTP and WebSocket endpoints independently before running the full bot
  
## Testing
  
```bash
  # Validate individual service endpoints
  python client/test/test_magpie_http.py
  python client/test/test_magpie_ws.py
  python client/test/test_asr_ws.py
  
  # Run HTTP bot (TTS on SageMaker)
  python client/bot/pipecat-bot-http.py
  
  # Run WebSocket bot (STT + TTS on SageMaker)
  python client/bot/pipecat-bot-ws.py

  # See DEPLOYMENT.md for full setup instructions including prerequisites, IAM configuration, NIM container deployment, and SageMaker endpoint creation.
```