### PR TITLE
Update phone-bot README to require Python 3.11+

### DIFF
--- a/gemini-live-starters/phone-bot/README.md
+++ b/gemini-live-starters/phone-bot/README.md
@@ -12,7 +12,7 @@ Call **1-970-LIVE-API** (1-970-548-3274) to talk to a Gemini Live Pipecat bot ov
 
 ### Environment
 
-- Python 3.10 or later
+- Python 3.11 or later
 - [uv](https://docs.astral.sh/uv/getting-started/installation/) package manager installed
 
 ### Service API keys


### PR DESCRIPTION
When following the instructions at [Gemini Phone Bots](https://github.com/pipecat-ai/pipecat-examples/tree/main/gemini-live-starters/phone-bot) using Python 3.10.20, I got the following error when running `uv run bot.py`

`Traceback (most recent call last):
  File "/home/user/Projects/pcc-gemini-twilio/bot.py", line 239, in <module>
    from pipecat.runner.run import main
  File "/home/user/Projects/pcc-gemini-twilio/.venv/lib/python3.10/site-packages/pipecat/runner/run.py", line 75, in <module>
    from http import HTTPMethod
ImportError: cannot import name 'HTTPMethod' from 'http' (/home/user/.pyenv/versions/3.10.20/lib/python3.10/http/__init__.py)
`

I installed Python 3.11.0 and it got past this error.