### PR TITLE
fix: typo “occured” → “occurred” in error message

### DIFF
--- a/push-to-talk/client/src/app/components/App.tsx
+++ b/push-to-talk/client/src/app/components/App.tsx
@@ -67,7 +67,7 @@ export const App = ({ handleConnect, handleDisconnect, error }: AppProps) => {
 
   if (error) {
     return (
-      <ErrorCard error={error} title="An error occured connecting to agent." />
+      <ErrorCard error={error} title="An error occurred connecting to agent." />
     );
   }
 


### PR DESCRIPTION
Fixes a typo in a user-facing error message (“occured” → “occurred”).