### PR TITLE
Add client-side tool calling to push-to-talk example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Ready to explore more? These are two of the most useful examples for common use 
 ### **Web & Client Applications**
 
 - **[simple-chatbot](simple-chatbot/)** - Client/server examples with React, JavaScript, Swift, Kotlin, and React Native
-- **[push-to-talk](push-to-talk/)** - Client/server example showing how to build a Push-to-Talk app using Voice UI Kit and Pipecat's JS and React SDKs
+- **[push-to-talk](push-to-talk/)** - Client/server example showing push-to-talk turn control and client-side tool calling, using Voice UI Kit and Pipecat's JS and React SDKs
 - **[websocket](websocket/)** - WebSocket-based real-time communication
 - **[instant-voice](instant-voice/)** - Enable instant voice communication as soon as a user connects
 - **[p2p-webrtc](p2p-webrtc/)** - Simple peer-to-peer WebRTC voice bot

--- a/push-to-talk/README.md
+++ b/push-to-talk/README.md
@@ -84,27 +84,6 @@ The strategies react to the `push_to_talk` message directly, so no separate fram
 
 This example also shows how to run an LLM tool call **in the browser** instead of on the server. Reach for this when the tool needs something only the client has: the DOM, geolocation, a local file, or a logged-in session. Here the tool is `get_browser_info`. Ask the bot "what browser am I using?" and it reads back your real user agent, screen size, language, and time zone, none of which the server ever saw.
 
-### How it works
-
-1. The server advertises the tool to the LLM in `LLMContext(tools=...)` and registers `run_on_client` as its handler.
-2. The LLM calls the tool. Pipecat tells the client the call is in progress via the `llm-function-call-in-progress` RTVI message.
-3. `run_on_client` returns **without** calling `params.result_callback`. That leaves the call open instead of answering it.
-4. The client's registered handler runs and returns a value, which the client sends back as `llm-function-call-result`.
-5. Pipecat turns that message into the function call's result, adds it to the LLM context, and runs the LLM again so the bot can talk about it.
-
-The two halves are `run_on_client` plus the `CLIENT_TOOL` wiring in `server/bot.py`, and `client/src/app/hooks/useClientTools.ts`. To add another client-run tool you need four things: a `FunctionSchema`, a `register_function` call, a report-level entry, and a matching `registerFunctionCallHandler` in the hook.
-
-### Things that will bite you
-
-Every one of these fails silently, so they are worth knowing up front.
-
-- **Set the report level.** `function_call_report_level` defaults to `NONE`, which sends only a `tool_call_id`. The client cannot dispatch a call it cannot name, so client-run tools must opt in to `FULL`.
-- **Return something non-empty.** An empty result (`null`, `{}`, `""`) is treated as "nothing to say" and the bot will not speak a follow-up.
-- **There is no timeout.** If the client never answers, the call stays open for the rest of the session and the bot just stops. Handle your own errors and always return a value.
-- **Interruption does not cancel these calls.** Once the server handler returns, Pipecat has nothing left to cancel. Press the talk button while a tool call is in flight and the result still lands in the context afterwards.
-- **Parallel calls are grouped.** If you add more client tools and the LLM calls several at once, one unanswered call blocks the whole group.
-- **Client SDK support.** This flow needs `@pipecat-ai/client-js` 1.6.0 or newer. Older web clients, and the current iOS and Android SDKs, only understand the deprecated `llm-function-call` message.
-
 ## Deploy your Bot to Pipecat Cloud
 
 Follow the [quickstart instructions](https://docs.pipecat.ai/getting-started/quickstart#step-2%3A-deploy-to-production) to deploy your bot to Pipecat Cloud.

--- a/push-to-talk/README.md
+++ b/push-to-talk/README.md
@@ -80,6 +80,31 @@ The push-to-talk functionality is encapsulated in custom [user turn strategies](
 
 The strategies react to the `push_to_talk` message directly, so no separate frame-handling processor is needed. (For an app that mixes push-to-talk with live VAD-driven turns, you'd instead translate the message into custom frames in an `on_client_message` handler — see [pipecat-ai/ptt-and-conversation](https://github.com/kwindla/ptt-and-conversation).)
 
+## Client-side Tool Calling
+
+This example also shows how to run an LLM tool call **in the browser** instead of on the server. Reach for this when the tool needs something only the client has: the DOM, geolocation, a local file, or a logged-in session. Here the tool is `get_browser_info`. Ask the bot "what browser am I using?" and it reads back your real user agent, screen size, language, and time zone, none of which the server ever saw.
+
+### How it works
+
+1. The server advertises the tool to the LLM in `LLMContext(tools=...)` and registers `run_on_client` as its handler.
+2. The LLM calls the tool. Pipecat tells the client the call is in progress via the `llm-function-call-in-progress` RTVI message.
+3. `run_on_client` returns **without** calling `params.result_callback`. That leaves the call open instead of answering it.
+4. The client's registered handler runs and returns a value, which the client sends back as `llm-function-call-result`.
+5. Pipecat turns that message into the function call's result, adds it to the LLM context, and runs the LLM again so the bot can talk about it.
+
+The two halves are `run_on_client` plus the `CLIENT_TOOL` wiring in `server/bot.py`, and `client/src/app/hooks/useClientTools.ts`. To add another client-run tool you need four things: a `FunctionSchema`, a `register_function` call, a report-level entry, and a matching `registerFunctionCallHandler` in the hook.
+
+### Things that will bite you
+
+Every one of these fails silently, so they are worth knowing up front.
+
+- **Set the report level.** `function_call_report_level` defaults to `NONE`, which sends only a `tool_call_id`. The client cannot dispatch a call it cannot name, so client-run tools must opt in to `FULL`.
+- **Return something non-empty.** An empty result (`null`, `{}`, `""`) is treated as "nothing to say" and the bot will not speak a follow-up.
+- **There is no timeout.** If the client never answers, the call stays open for the rest of the session and the bot just stops. Handle your own errors and always return a value.
+- **Interruption does not cancel these calls.** Once the server handler returns, Pipecat has nothing left to cancel. Press the talk button while a tool call is in flight and the result still lands in the context afterwards.
+- **Parallel calls are grouped.** If you add more client tools and the LLM calls several at once, one unanswered call blocks the whole group.
+- **Client SDK support.** This flow needs `@pipecat-ai/client-js` 1.6.0 or newer. Older web clients, and the current iOS and Android SDKs, only understand the deprecated `llm-function-call` message.
+
 ## Deploy your Bot to Pipecat Cloud
 
 Follow the [quickstart instructions](https://docs.pipecat.ai/getting-started/quickstart#step-2%3A-deploy-to-production) to deploy your bot to Pipecat Cloud.

--- a/push-to-talk/client/package-lock.json
+++ b/push-to-talk/client/package-lock.json
@@ -8,10 +8,10 @@
       "name": "02-components",
       "version": "0.1.0",
       "dependencies": {
-        "@pipecat-ai/client-js": "^1.10.0",
-        "@pipecat-ai/client-react": "^1.6.0",
-        "@pipecat-ai/daily-transport": "^1.6.5",
-        "@pipecat-ai/voice-ui-kit": "^0.11.0",
+        "@pipecat-ai/client-js": "^1.13.0",
+        "@pipecat-ai/client-react": "^1.8.1",
+        "@pipecat-ai/daily-transport": "^1.6.8",
+        "@pipecat-ai/voice-ui-kit": "^0.13.0",
         "lucide-react": "^0.511.0",
         "next": "15.3.4",
         "react": "^19.0.0",
@@ -1043,9 +1043,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.10.0.tgz",
-      "integrity": "sha512-5V0pF1LgKlDiYA7teaDdOVtoU7EDvb4LDIAkP4xIRThL6xNB2A+4v1VxrO8qfgLEUJ6UqwakhYJIowc9wpHKAw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.13.0.tgz",
+      "integrity": "sha512-Gep0ji+3Qxo8rm10nnfsS7xhpCUgr40ZNwx8fLroKhW/Cz4eAHjbdxmfnUPNklGBUqcEwEgyZchrfDN2kMCisw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/events": "^3.0.3",
@@ -1057,9 +1057,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-react": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-react/-/client-react-1.6.0.tgz",
-      "integrity": "sha512-JE3BnUTTXfaXxpIhZF0z1jtMGNAvxFcR9BqWkdHxmUqs45NNqK8D0hFEK661Ov7pU1fAOrYaDu/qbNg1sE/YcA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-react/-/client-react-1.8.1.tgz",
+      "integrity": "sha512-558BVmslUuhjOr2e8mrpmOrWJJ47fcacw/EeZ0CyvHj8j2Doh4GDvsFSjnPT123BCaFB4JBP63z7SiQRwujRFg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "jotai": "^2.9.0"
@@ -1071,21 +1071,21 @@
       }
     },
     "node_modules/@pipecat-ai/daily-transport": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/daily-transport/-/daily-transport-1.6.5.tgz",
-      "integrity": "sha512-8GAi7e77+s/V0At04CBH+6VyAjfoQ+rFteWhS0MCDyPO9bbbcPiln6rfpMPp3ocKZdPG/7g8DmLkZrbFxWZ/qA==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/daily-transport/-/daily-transport-1.6.8.tgz",
+      "integrity": "sha512-6yBbgKCGTWwx1QFAbp5T5FjxnNdvLr49g4SyteoPeq6VduBGtlFAyrEwYt4Bt6eRAsCrGFpS41SkDyykxLF7Eg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.13.0"
       }
     },
     "node_modules/@pipecat-ai/voice-ui-kit": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/voice-ui-kit/-/voice-ui-kit-0.11.0.tgz",
-      "integrity": "sha512-MCmczYg6mBsIi9KdK+6w/ROuVJpcpcXzt3QTBw1THmhImxyBrPNKpmPik++bndNQbdXzUam8+C5FHqMLNSJlcA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/voice-ui-kit/-/voice-ui-kit-0.13.0.tgz",
+      "integrity": "sha512-pQD11d99AxX5GM2J95nwajnWH8Z9joy9+NcaL2uL91v7O1odkXKEZNjc9+exc0dFKokIsE8KWIQO0vomZuNKGQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@radix-ui/react-collapsible": "^1.1.7",
@@ -1107,6 +1107,7 @@
         "react-resizable-panels": "^3.0.6",
         "semver": "^7.6.3",
         "tailwind-merge": "^3.3.1",
+        "vaul": "^1.1.2",
         "zustand": "^5.0.8"
       },
       "engines": {
@@ -1114,9 +1115,10 @@
       },
       "peerDependencies": {
         "@daily-co/daily-js": ">=0.84.0",
-        "@pipecat-ai/client-js": ">=1.8.0",
-        "@pipecat-ai/client-react": ">=1.4.0",
+        "@pipecat-ai/client-js": ">=1.13.0",
+        "@pipecat-ai/client-react": ">=1.8.0",
         "@pipecat-ai/daily-transport": ">=1.6.0",
+        "@pipecat-ai/moq-transport": "^0.1.0",
         "@pipecat-ai/small-webrtc-transport": ">=1.9.0",
         "@pipecat-ai/websocket-transport": ">=1.6.2",
         "react": ">=16.8.0 || >=17.0.0 || >=18.0.0",
@@ -1138,6 +1140,10 @@
         },
         "@pipecat-ai/daily-transport": {
           "version": "^1.6.0",
+          "optional": true
+        },
+        "@pipecat-ai/moq-transport": {
+          "version": "^0.1.0",
           "optional": true
         },
         "@pipecat-ai/small-webrtc-transport": {
@@ -1263,6 +1269,320 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -6367,9 +6687,9 @@
       "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
-      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
       "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
@@ -7473,6 +7793,19 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/which": {

--- a/push-to-talk/client/package-lock.json
+++ b/push-to-talk/client/package-lock.json
@@ -8,6 +8,8 @@
       "name": "02-components",
       "version": "0.1.0",
       "dependencies": {
+        "@pipecat-ai/client-js": "^1.10.0",
+        "@pipecat-ai/client-react": "^1.6.0",
         "@pipecat-ai/daily-transport": "^1.6.5",
         "@pipecat-ai/voice-ui-kit": "^0.11.0",
         "lucide-react": "^0.511.0",
@@ -1045,7 +1047,6 @@
       "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.10.0.tgz",
       "integrity": "sha512-5V0pF1LgKlDiYA7teaDdOVtoU7EDvb4LDIAkP4xIRThL6xNB2A+4v1VxrO8qfgLEUJ6UqwakhYJIowc9wpHKAw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@types/events": "^3.0.3",
         "bowser": "^2.11.0",
@@ -1060,7 +1061,6 @@
       "resolved": "https://registry.npmjs.org/@pipecat-ai/client-react/-/client-react-1.6.0.tgz",
       "integrity": "sha512-JE3BnUTTXfaXxpIhZF0z1jtMGNAvxFcR9BqWkdHxmUqs45NNqK8D0hFEK661Ov7pU1fAOrYaDu/qbNg1sE/YcA==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "jotai": "^2.9.0"
       },
@@ -2363,8 +2363,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
       "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -3455,7 +3454,6 @@
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
       "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
@@ -5113,7 +5111,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -5285,7 +5282,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5323,7 +5319,6 @@
       "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.20.0.tgz",
       "integrity": "sha512-b5GAqgmXmXzB4WPaTH26ppk9Sl7AA9WSQX7yfdM+gJ1rFROiWcVbi97gFuN/yVCojOcbcvop2sfLL+fjxW0JVg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },
@@ -5433,7 +5428,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6577,7 +6571,6 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -6709,7 +6702,6 @@
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "kind-of": "^6.0.2"
       },
@@ -7338,7 +7330,6 @@
       "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
       "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "rxjs": "*"
       }
@@ -7480,7 +7471,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }

--- a/push-to-talk/client/package.json
+++ b/push-to-talk/client/package.json
@@ -9,10 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.10.0",
-    "@pipecat-ai/client-react": "^1.6.0",
-    "@pipecat-ai/daily-transport": "^1.6.5",
-    "@pipecat-ai/voice-ui-kit": "^0.11.0",
+    "@pipecat-ai/client-js": "^1.13.0",
+    "@pipecat-ai/client-react": "^1.8.1",
+    "@pipecat-ai/daily-transport": "^1.6.8",
+    "@pipecat-ai/voice-ui-kit": "^0.13.0",
     "lucide-react": "^0.511.0",
     "next": "15.3.4",
     "react": "^19.0.0",

--- a/push-to-talk/client/package.json
+++ b/push-to-talk/client/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@pipecat-ai/client-js": "^1.10.0",
+    "@pipecat-ai/client-react": "^1.6.0",
     "@pipecat-ai/daily-transport": "^1.6.5",
     "@pipecat-ai/voice-ui-kit": "^0.11.0",
     "lucide-react": "^0.511.0",

--- a/push-to-talk/client/src/app/components/App.tsx
+++ b/push-to-talk/client/src/app/components/App.tsx
@@ -12,6 +12,7 @@ import { PlasmaVisualizer } from '@pipecat-ai/voice-ui-kit/webgl';
 import { LogOutIcon, XIcon, MicIcon } from 'lucide-react';
 import { usePipecatClient } from '@pipecat-ai/client-react';
 import { useCallback, useState } from 'react';
+import { useClientTools } from '../hooks/useClientTools';
 
 export interface AppProps {
   handleConnect?: () => void | Promise<void>;
@@ -64,6 +65,9 @@ const PushToTalkButton = () => {
 
 export const App = ({ handleConnect, handleDisconnect, error }: AppProps) => {
   const { isConnected } = usePipecatConnectionState();
+
+  // Tools the LLM calls that run here in the browser, not on the server.
+  useClientTools();
 
   if (error) {
     return (

--- a/push-to-talk/client/src/app/hooks/useClientTools.ts
+++ b/push-to-talk/client/src/app/hooks/useClientTools.ts
@@ -27,7 +27,8 @@ export function useClientTools() {
           timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         };
       } catch (error) {
-        return { error: `Could not read browser info: ${error}` };
+        const message = error instanceof Error ? error.message : String(error);
+        return { error: `Could not read browser info: ${message}` };
       }
     });
 

--- a/push-to-talk/client/src/app/hooks/useClientTools.ts
+++ b/push-to-talk/client/src/app/hooks/useClientTools.ts
@@ -1,0 +1,30 @@
+import { usePipecatClient } from '@pipecat-ai/client-react';
+import { useEffect } from 'react';
+
+/**
+ * Registers tools that the bot's LLM calls, but that run here in the browser.
+ *
+ * The server advertises `get_browser_info` to the LLM and then hands the call
+ * straight back to us (see `run_on_client` in `server/bot.py`). The LLM waits
+ * until the value we return below reaches its context.
+ */
+export function useClientTools() {
+  const client = usePipecatClient();
+
+  useEffect(() => {
+    if (!client) return;
+
+    // Data only the browser has. Always return something truthy: an empty
+    // result stops the bot from speaking a follow-up.
+    client.registerFunctionCallHandler('get_browser_info', async () => ({
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      screen: `${window.screen.width}x${window.screen.height}`,
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    }));
+
+    return () => {
+      client.unregisterFunctionCallHandler('get_browser_info');
+    };
+  }, [client]);
+}

--- a/push-to-talk/client/src/app/hooks/useClientTools.ts
+++ b/push-to-talk/client/src/app/hooks/useClientTools.ts
@@ -14,14 +14,22 @@ export function useClientTools() {
   useEffect(() => {
     if (!client) return;
 
-    // Data only the browser has. Always return something truthy: an empty
-    // result stops the bot from speaking a follow-up.
-    client.registerFunctionCallHandler('get_browser_info', async () => ({
-      userAgent: navigator.userAgent,
-      language: navigator.language,
-      screen: `${window.screen.width}x${window.screen.height}`,
-      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    }));
+    // Data only the browser has. Always return a value, and never let the
+    // handler throw. Throwing, or returning null/undefined, sends nothing
+    // back, and the bot then waits on this call for the rest of the session.
+    // Telling the LLM it failed is always better than going silent.
+    client.registerFunctionCallHandler('get_browser_info', async () => {
+      try {
+        return {
+          userAgent: navigator.userAgent,
+          language: navigator.language,
+          screen: `${window.screen.width}x${window.screen.height}`,
+          timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        };
+      } catch (error) {
+        return { error: `Could not read browser info: ${error}` };
+      }
+    });
 
     return () => {
       client.unregisterFunctionCallHandler('get_browser_info');

--- a/push-to-talk/server/bot.py
+++ b/push-to-talk/server/bot.py
@@ -8,6 +8,8 @@ import os
 
 from dotenv import load_dotenv
 from loguru import logger
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.frames.frames import (
     Frame,
     LLMRunFrame,
@@ -21,11 +23,16 @@ from pipecat.processors.aggregators.llm_response_universal import (
     LLMContextAggregatorPair,
     LLMUserAggregatorParams,
 )
-from pipecat.processors.frameworks.rtvi import RTVIClientMessageFrame
+from pipecat.processors.frameworks.rtvi import (
+    RTVIClientMessageFrame,
+    RTVIFunctionCallReportLevel,
+    RTVIObserverParams,
+)
 from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import create_transport
 from pipecat.services.cartesia.tts import CartesiaTTSService
 from pipecat.services.deepgram.stt import DeepgramSTTService
+from pipecat.services.llm_service import FunctionCallParams
 from pipecat.services.openai.llm import OpenAILLMService
 from pipecat.transports.base_transport import BaseTransport, TransportParams
 from pipecat.transports.daily.transport import DailyParams
@@ -50,6 +57,33 @@ transport_params = {
         audio_out_enabled=True,
     ),
 }
+
+# This tool runs in the browser, not here. See `run_on_client` below and
+# `client/src/app/hooks/useClientTools.ts` for the other half.
+CLIENT_TOOL = "get_browser_info"
+
+tools = ToolsSchema(
+    standard_tools=[
+        FunctionSchema(
+            name=CLIENT_TOOL,
+            description="Get information about the user's browser and screen.",
+            properties={},
+            required=[],
+        ),
+    ]
+)
+
+
+async def run_on_client(params: FunctionCallParams):
+    """Hand this tool to the client.
+
+    We deliberately return without calling params.result_callback. That leaves
+    the function call open. The RTVI observer has already told the client the
+    call is in progress, the client runs it, and the client's
+    llm-function-call-result message becomes the FunctionCallResultFrame that
+    completes the call and lets the LLM continue.
+    """
+    logger.debug(f"Delegating {params.function_name} to the client")
 
 
 class PushToTalkUserTurnStartStrategy(BaseUserTurnStartStrategy):
@@ -127,11 +161,22 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
     llm = OpenAILLMService(
         api_key=os.getenv("OPENAI_API_KEY"),
         settings=OpenAILLMService.Settings(
-            system_instruction="You are a helpful assistant. Your output will be converted to audio so don't include special characters in your answers. Respond to what the user said in a creative and helpful way.",
+            system_instruction=(
+                "You are a helpful assistant. Your output will be converted to audio so don't "
+                "include special characters in your answers. Respond to what the user said in a "
+                "creative and helpful way. You have a get_browser_info tool that runs in the "
+                "user's own browser, so use it whenever they ask about their browser, screen, "
+                "language, or time zone, and read the answer back to them."
+            ),
         ),
     )
 
-    context = LLMContext()
+    context = LLMContext(tools=tools)
+
+    # The tool is advertised to the LLM here, but the browser is what actually
+    # runs it.
+    llm.register_function(CLIENT_TOOL, run_on_client)
+
     # The push-to-talk button is the sole authority over user turns. The custom
     # strategies react to the client's `push_to_talk` message: the aggregator
     # only collects transcription between a button press and release, then pushes
@@ -160,6 +205,15 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         params=PipelineParams(
             enable_metrics=True,
             enable_usage_metrics=True,
+        ),
+        # The client can only dispatch a tool call if it knows the function
+        # name and arguments. The default report level is NONE, which sends
+        # only the tool_call_id, so client-run tools must opt in to FULL.
+        rtvi_observer_params=RTVIObserverParams(
+            function_call_report_level={
+                "*": RTVIFunctionCallReportLevel.NONE,
+                CLIENT_TOOL: RTVIFunctionCallReportLevel.FULL,
+            }
         ),
     )
 

--- a/push-to-talk/server/bot.py
+++ b/push-to-talk/server/bot.py
@@ -66,7 +66,13 @@ tools = ToolsSchema(
     standard_tools=[
         FunctionSchema(
             name=CLIENT_TOOL,
-            description="Get information about the user's browser and screen.",
+            description=(
+                "Get information about the user's browser and screen. Takes no "
+                "arguments. The browser returns userAgent, language, screen, and "
+                "timeZone. See `useClientTools.ts` on the client for the values."
+            ),
+            # No input arguments: everything this tool reports comes back from
+            # the browser in the result, not from the LLM.
             properties={},
             required=[],
         ),

--- a/push-to-talk/server/bot.py
+++ b/push-to-talk/server/bot.py
@@ -69,7 +69,7 @@ tools = ToolsSchema(
             description=(
                 "Get information about the user's browser and screen. Takes no "
                 "arguments. The browser returns userAgent, language, screen, and "
-                "timeZone. See `useClientTools.ts` on the client for the values."
+                "timeZone."
             ),
             # No input arguments: everything this tool reports comes back from
             # the browser in the result, not from the LLM.


### PR DESCRIPTION
## What

Shows how to run an LLM tool call **in the browser** instead of on the server, using the current RTVI flow rather than the deprecated `RTVIProcessor.handle_function_call`.

The example tool is `get_browser_info`. Ask the bot "what browser am I using?" and it reads back your real user agent, screen size, language, and time zone, none of which the server ever saw.

## How it works

1. The server advertises the tool in `LLMContext(tools=...)` and registers `run_on_client` as its handler.
2. The LLM calls it. Pipecat tells the client via `llm-function-call-in-progress`.
3. `run_on_client` returns **without** calling `params.result_callback`, which leaves the call open instead of answering it.
4. The browser handler runs and returns a value, sent back as `llm-function-call-result`.
5. Pipecat turns that into the call's result, adds it to context, and reruns the LLM.

Two halves: `run_on_client` plus the `CLIENT_TOOL` wiring in `server/bot.py`, and `client/src/app/hooks/useClientTools.ts`.

## Why push-to-talk

- It already demos **client to server** messaging via `sendClientMessage`, so this completes the two-way picture in one example.
- It has a single client, which matters here. A tool the client never answers leaves the call open for the rest of the session, because `function_call_timeout_secs` does not cover deferred calls (the timeout task is cancelled as soon as the handler returns). Adding this to a multi-client example would hang the bot for every client that did not get the handler.

## Note on the report level

Client-run tools must opt in to `FULL`. `function_call_report_level` defaults to `NONE`, which sends only a `tool_call_id`, and a client cannot dispatch a call it cannot name. Other tools stay at the secure default.

## Verified end to end

Run against a live Daily session on 2026-08-12. Pipecat 1.7.0, `@pipecat-ai/client-js` 1.13.0, `client-react` 1.8.1, `daily-transport` 1.6.8, `voice-ui-kit` 0.13.0. Asked the bot out loud for browser info:

```
12:10:26.305  Calling function [get_browser_info:call_NJ8...] with arguments {}
12:10:26.306  Delegating get_browser_info to the client        <- no-op handler, call left open
12:10:26.310  FunctionCallInProgressFrame                       <- client told
12:10:26.558  FunctionCallResultFrame                           <- client answered, 253 ms
```

The LLM then reran with the browser's real data in context, which the server never had:

```json
{"language": "en-US", "screen": "1728x1117", "timeZone": "Asia/Taipei",
 "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ... Chrome/151.0.0.0 Safari/537.36"}
```

Note `arguments {}`: the tool takes no inputs, which is why `properties` is empty.

Barge-in while the bot is **speaking** also works: five clean interruptions in the same session, each starting a fresh user turn.

