### PR TITLE
Add phonellm example

### DIFF
--- a/phonellm/.claude/skills/setup/SKILL.md
+++ b/phonellm/.claude/skills/setup/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: setup
+description: Walk through this repo's full setup start to finish — install the Pipecat and Modal CLIs, provision PhoneLLM on Modal, create and authorize a proxy token, configure server/.env, health-check the endpoint, sync dependencies, and verify the bot with a headless eval. Use when setting up the project fresh, when the bot can't reach its services, or when the user asks to (re)initialize the project.
+---
+
+# PhoneLLM Example setup
+
+Step through the README's setup flow end to end, verifying each step before moving on.
+Ask the user whenever a step needs their input or approval — never invent credentials,
+never create billable infrastructure without confirming first, and never print secret
+values to the terminal (write them straight to `server/.env`).
+
+Work from the repo root. The bot lives in `server/`.
+
+## 1. CLIs
+
+Check `pipecat --version` and `modal --version`. Install whichever is missing:
+
+```bash
+uv tool install "pipecat-ai[cli]"
+uv tool install modal
+```
+
+## 2. Modal auth
+
+Check auth with `modal profile current` (fast, non-interactive). If it fails, the user
+must log in themselves — it's a browser flow. Ask them to run:
+
+```
+! modal setup
+```
+
+There is no `modal login`; `modal setup` is the auth command.
+
+## 3. PhoneLLM endpoint
+
+Check for an existing endpoint: `modal endpoint list --json`, looking for a live
+`phonellm-alpha-1`. If present, skip to step 4.
+
+If absent, **ask the user before creating** (it provisions GPU infrastructure —
+takes ~20–30 minutes and bills their workspace):
+
+```bash
+modal endpoint create --model pipecat-ai/phonellm-alpha-1
+```
+
+**Capture the endpoint URL from the create output immediately** — the CLI cannot
+retrieve it later (`modal endpoint list` shows status only). Then poll
+`modal endpoint list --json` every ~30s (in the background) until status is `live`.
+
+## 4. Endpoint URL
+
+If `MODAL_ENDPOINT_URL` is already in `server/.env`, keep it. If you just ran
+`endpoint create`, use the URL from its output. Otherwise **ask the user to paste it**
+from their create-output scrollback or the endpoint's page in the Modal dashboard
+(`modal dashboard`). Do not guess hostnames — the URL's label is not derivable from
+the endpoint name.
+
+## 5. Proxy token
+
+If `MODAL_API_KEY` is already in `server/.env`, keep it. Otherwise create one:
+
+```bash
+modal workspace proxy-tokens create --json
+```
+
+Combine as `<token-id>.<token-secret>` (`wk-....ws-...`) and write it to `server/.env`
+without echoing the secret. The secret is shown once and cannot be retrieved later.
+
+On RBAC workspaces the new token has no environment access and the endpoint will
+return `401 "Webhook token not found"`. Authorize it (the endpoint lives in `main`
+unless created elsewhere):
+
+```bash
+modal workspace proxy-tokens allow <token-id> main
+```
+
+## 6. Configure .env
+
+If `server/.env` doesn't exist, `cp server/.env.example server/.env`. Ensure it has:
+
+- `DEEPGRAM_API_KEY` — **ask the user for it** if missing; never invent keys.
+- `MODAL_ENDPOINT_URL` — from step 4.
+- `MODAL_API_KEY` — from step 5.
+
+## 7. Health-check the endpoint
+
+```bash
+curl -s --max-time 60 -w "\nHTTP %{http_code}\n" "$MODAL_ENDPOINT_URL/v1/models" \
+  -H "Authorization: Bearer $MODAL_API_KEY"
+```
+
+Interpret the result:
+
+- **200** with a model list naming `pipecat-ai/phonellm-alpha-1` — healthy, continue.
+- **503, empty body** — scale-to-zero cold start; the request itself triggers spin-up.
+  Retry every ~30s (in the background). A 30B model can take several minutes. An
+  *instant* 503 that persists well past 10 minutes suggests a wrong URL — re-verify
+  with the user rather than retrying forever.
+- **401 "Webhook token not found"** — the RBAC `allow` step (5) is missing.
+
+Optionally verify the exact request path the bot uses:
+
+```bash
+curl -s "$MODAL_ENDPOINT_URL/v1/chat/completions" \
+  -H "Authorization: Bearer $MODAL_API_KEY" -H "Content-Type: application/json" \
+  -d '{"model": "pipecat-ai/phonellm-alpha-1", "messages": [{"role": "user", "content": "Hello!"}]}'
+```
+
+## 8. Dependencies and lint
+
+```bash
+cd server && uv sync
+uv run ruff check bot.py && uv run pyright bot.py
+```
+
+## 9. Verify the bot headless
+
+Boot the bot with the eval transport (background, keep the log):
+
+```bash
+uv run bot.py -t eval 2>&1 | tee /tmp/phonellm-eval-bot.log
+```
+
+Confirm it reaches "Bot ready!" with no traceback, then in a second shell run the
+smoke scenario (deterministic checks only — no judge LLM needed):
+
+```bash
+uv run pipecat eval run evals/phonellm_smoke.yaml -v
+```
+
+If port 7860 is taken (e.g. the user's own `uv run bot.py` is running — check with
+`lsof -nP -iTCP:7860 -sTCP:LISTEN`), don't kill their process: boot the eval bot on
+another port with `--port 7861` and pass `--bot-url ws://localhost:7861` to the eval.
+
+All turns passing proves the whole pipeline against the live endpoint: greeting,
+a factual answer ("Berlin"), and multi-turn context ("Paris"). On failure, grep the
+bot log for the traceback before re-running; a 503 from the LLM means the endpoint
+went cold again — warm it (step 7) and re-run.
+
+## 10. Done
+
+Tell the user to start the bot and talk to it:
+
+```bash
+uv run bot.py
+```
+
+Browser test UI: http://localhost:7860.

--- a/phonellm/.gitignore
+++ b/phonellm/.gitignore
@@ -1,0 +1,223 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml
+
+# Pipecat eval artifacts
+*.eval.log
+*.debug.log
+eval-runs/
+
+# Node.js (client/)

--- a/phonellm/AGENTS.md
+++ b/phonellm/AGENTS.md
@@ -1,0 +1,300 @@
+# AGENTS.md — Building Pipecat Apps
+
+> Guidance for AI coding agents building **applications** with Pipecat.
+> This is **not** about contributing to the Pipecat framework itself — for that, see the framework's own AGENTS.md.
+>
+> Audience: any coding agent (Claude Code, Codex, …).
+
+---
+
+## 0. Golden rules (non-negotiable)
+
+1. **Scaffold first. Never hand-write boilerplate.** Start every new app from the Pipecat CLI scaffold (§1) — it generates a *runnable* bot (services + pipeline already wired), not a bare skeleton. Modify what it generates; don't rebuild it or invent your own structure.
+2. **Don't guess — learn, then verify.** Pipecat moves fast and your priors are stale. When a capability is unfamiliar, **learn how it works first** (§3 `search_docs`) instead of jumping into code; then confirm every class, import, and param against a **live source** (§3) as you write. Confidently-wrong old APIs are the #1 failure mode.
+3. **Make it verifiable before you make it fancy.** Pipecat ships a behavioral **eval harness** (§6): scaffold with `--eval` and check every change by running scenarios headless — no live voice call. Stand up that loop before adding features.
+4. **Ask for credentials; don't invent them.** Model names, voice IDs, and API keys are provider-specific and change often. If you don't have one, stop and ask — list exactly which keys are needed.
+
+---
+
+## 1. Start by scaffolding
+
+Always begin from the deterministic CLI scaffold. It gives you a known-good structure, correct dependencies, a runnable entry point, and the deploy path for free.
+
+```bash
+# The CLI ships *with* pipecat-ai, behind the optional `cli` extra. Install it as a global tool:
+uv tool install "pipecat-ai[cli]"   # provides the `pipecat` (alias `pc`) command
+```
+
+> ⚠️ **Agents: scaffold non-interactively** — bare `pipecat init` (no scaffold flags) opens an interactive wizard that **hangs an automated run**. Pass your choices as flags (or `--config`):
+
+```bash
+# Headless: any scaffold flag (--bot-type, a service, or --config) switches off the wizard.
+# Run it in the project directory you're already in; `.` scaffolds in place, name from the dir.
+# The service values below are EXAMPLES — map the user's actual choices, don't copy these.
+pipecat init . \
+  --transport smallwebrtc --mode cascade \
+  --stt deepgram_stt --llm openai_llm --tts cartesia_tts \
+  --eval                             # eval transport + starter scenarios, for verification (§6)
+#   • Don't hand-write flags from memory — discover them:
+#       pipecat init --help          # available flags
+#       pipecat init --list-options  # valid service/transport VALUES
+#   • --dry-run prints the resolved config as JSON; --config project.json drives it from a file.
+#   • --transport is repeatable — pass each transport you want (production + a local-dev one, §2).
+#   • --bot-type is inferred from --transport (telephony if any telephony transport, else web) — omit it.
+```
+
+**Choose *with* the user, not for them.** Map their requirements to the real options and confirm transport / services / mode / deployment (§7) before scaffolding — don't silently pick or guess. Mode affects testing speed — **cascade (STT→LLM→TTS)** gets the fast text-mode eval loop (§6); **realtime (speech-to-speech)** is tested in audio mode — but both run headless, so pick the mode the use case needs.
+
+**No Context Hub tools in this session?** (Check your tool list — §3 rung 1.) The §3 rung-2 shell commands are equivalent and need no restart, so nothing is blocked *once the index exists*. On a cold start it doesn't: every hub command, MCP and CLI alike, exits 2 until `refresh` has run. Confirm with `pipecat context-hub status` before relying on either.
+
+`pipecat init` registers the hub's MCP server when it writes the agent guides, but not on this scaffold path — and MCP servers are read only at session start either way. Register it so later sessions have it:
+
+```bash
+pipecat context-hub install --no-refresh   # instant and idempotent; skips the index build
+```
+
+Registration alone leaves the hub **unusable**: every tool errors until the index exists. Registration is free, so just do it. The index is the real decision, so ask, and ask **early** (alongside the transport/service questions above) because a yes runs for several minutes in the background while you scaffold and sync:
+
+> "The Context Hub gives me current Pipecat docs and API signatures instead of my training data. Building its index takes 5 to 10 minutes and about 750 MB plus model downloads. Want it? Without it I'll read the installed package source instead (§3 rung 3)."
+
+Then *offer* the restart rather than pressing for it: it loads the tools directly, but costs the user their session, and the CLI is equivalent. Worth raising at the start of a task, not in the middle of one.
+
+The scaffold pins a Pipecat version (treat it as the world you're building in — §3) and produces:
+
+```
+mybot/
+├── server/
+│   ├── bot.py            # entry point: an async `bot(runner_args)` function + `main()`
+│   ├── evals/            # starter eval scenarios, with --eval (§6)
+│   ├── pyproject.toml
+│   ├── .env.example      # required env vars
+│   ├── Dockerfile        # if cloud enabled
+│   └── pcc-deploy.toml   # deploy config, if cloud enabled
+├── client/               # web client, if generated
+└── README.md
+```
+
+**`bot.py` is a runnable bot, not a blank skeleton.** For the services you chose, the scaffold emits the **constructed service objects** (keys read from env), the `transport_params`, the canonical pipeline + context aggregators, the runner wiring, and an on-connect handler that speaks the first turn. **Modify it in place** — system prompt, function-calling tools (§4 shows the pattern), business logic, the greeting — do **not** re-declare the service constructors, rebuild the pipeline, or write your own connect handler. Nearly every provider is a scaffold value; hand-wire a service only if `--list-options` genuinely doesn't list it.
+
+Every bot exposes an async `bot(runner_args)` entry point that the dev runner discovers and executes per session. Keep that contract.
+
+> If the user already has an app, do **not** re-scaffold — read their existing structure and follow it.
+
+---
+
+## 2. Choosing transport & services
+
+Transport and services are scaffold inputs (the `--transport` / `--stt` / `--llm` / `--tts` flags) — map the use case to them before you scaffold, and confirm exact class names and params via §3.
+
+**Transport — by where the bot runs:**
+- **Web / mobile voice** — `DailyTransport` or `SmallWebRTCTransport`.
+- **Telephony** — a WebSocket transport (`FastAPIWebsocketTransport`) + the provider's serializer (Twilio, Telnyx, …), or `DailyTransport` for Daily PSTN/SIP.
+
+**Scaffold every transport you need at once** — repeat `--transport` (e.g. `--transport twilio --transport smallwebrtc`); the scaffold wires each one's params and dependencies. They coexist in `transport_params`; `-t <name>` picks one per run. `--bot-type` is inferred from your transports (telephony if any telephony transport, else web), so you can omit it. A **telephony** bot can include a WebRTC transport for local testing. A convenient dev setup is your production transport *plus*:
+- **`SmallWebRTCTransport` + Pipecat Prebuilt** — scaffold it in (`--transport smallwebrtc`) for a built-in browser test UI at `http://localhost:7860`, so you can talk to the bot with no telephony/PSTN setup — how you dev/test a **telephony** bot locally.
+- **the `eval` transport (§6)** — drive it headless with scripted scenarios to confirm behavior, tune prompts, and catch regressions.
+
+**Services** — STT, TTS, LLM are independent choices. Confirm the exact service class, model name, and params via §3; do not assume. Services configure via the current `settings=` argument.
+
+When the user describes a use case, find the closest example via `search_examples` (§3) and start there.
+
+---
+
+## 3. Find current truth (anti-staleness)
+
+You have live sources for current truth — never substitute your memory. Use the **highest rung of this ladder that works right now** — every rung is something you can do yourself, so never fall back to guessing:
+
+1. **The `pipecat-context-hub` MCP** (check your tool list) — the warm path; returns *primary source*. Two intents:
+   - **Learn the concept** (before building something unfamiliar): `search_docs` — how a capability works (the Learn guides) and how to use an optional feature (the Fundamentals guides — recording, transcripts, metrics, idle detection, muting, IVR, voicemail, …); `get_doc` — read a page in full. `search_examples` / `get_example` — a working implementation to start from. When asked for a feature, search it rather than guess.
+   - **Verify a specific API** (as you write): `check_deprecation` — **run on any symbol you're unsure about** (the stale-training antidote, e.g. `PipelineTask`→`PipelineWorker`); `search_api` / `get_code_snippet` — exact current signatures and usage. Examples can lag the framework — `check_deprecation` any symbol you copy from one.
+
+   The index is **local** — check `get_hub_status` for `last_refresh_at`, and refresh (`pipecat context-hub refresh`, or `uvx pipecat-ai-context-hub@latest refresh`) when it's stale or after a Pipecat version bump. Refresh pins the index to pipecat **main** by default; pass `--framework-version latest` so it matches the release your project runs.
+2. **No MCP? Query the same index from your shell** — same handlers, same JSON. The Context Hub ships with `pipecat-ai[cli]`, so wherever `pipecat` is on PATH these work; `pipecat context-hub --help` lists them. Where it isn't, the `uvx` form below needs no install at all.
+   ```bash
+   pipecat context-hub search-docs "turn detection"                      # learn a concept
+   pipecat context-hub check-deprecation PipelineTask                    # the reflex check; <1s
+   pipecat context-hub search-api "EvalTransportParams"
+   pipecat context-hub search-examples "twilio bot" --domain backend
+   pipecat context-hub status                                            # index health / freshness
+
+   uvx pipecat-ai-context-hub search-docs "turn detection"       # same, without the CLI
+   ```
+   Stdout is the tool's JSON. **Exit 2 means the local index isn't built yet** — tell the user, since building it takes 5 to 10 minutes and about 750 MB (plus model downloads on first run) and is their call: `pipecat context-hub refresh` (or `uvx pipecat-ai-context-hub@latest refresh`). Then re-run the query.
+
+   **Mention how the MCP tools get enabled**, without pressing for it: `pipecat context-hub install --no-refresh` registers the server, and restarting loads it. MCP servers are read only at session start, never mid-session — so keep using these shell commands for the current one. They are equivalent, so a restart is a convenience, not a fix.
+3. **Installed package source** — the pinned version is on disk; the code cannot be stale. Read it when the index is ambiguous:
+   ```bash
+   python -c "import pipecat, os; print(os.path.dirname(pipecat.__file__))"
+   ```
+4. **`llms.txt`** — machine-readable docs index at `https://docs.pipecat.ai/llms.txt` (full content: `llms-full.txt`). The last resort when nothing local works.
+
+(Naming: the *package* is `pipecat-ai-context-hub`; the standalone command and MCP server are `pipecat-context-hub`; mounted in the CLI it is `pipecat context-hub`. All resolve to the same tool.)
+
+For browsing examples directly, the **`pipecat-examples` repo** groups demos by category in its README (telephony, vision, etc.); `scripts/demos.json` lists each example's run command.
+
+**Rule of thumb:** if you're about to type a Pipecat class name, import path, or service parameter from memory — stop and run `check_deprecation` / `search_api` first (MCP, or the rung-2 CLI).
+
+---
+
+## 4. Mental model (concepts, not APIs)
+
+These concepts are stable even as signatures change — internalize them so your code flows correctly.
+
+**Terminology (current).** Get this vocabulary right — the framework renamed these and old terms are deprecated:
+- **Worker** — the top-level runnable unit. A single bot is a `PipelineWorker` (it wraps your pipeline). *Replaces the old "pipeline task"; `PipelineTask` is a deprecated alias.*
+- **Job / job group** — cross-worker RPC in multi-worker apps. Don't call these "agents." (The former `pipecat-subagents` package is folded into `pipecat.workers`.)
+- **Task** — means *only* an asyncio task. Don't use "task" for the runnable unit.
+
+Core concepts:
+
+- **Everything is a Frame moving through a pipeline of FrameProcessors.** Frames flow **downstream** (input → output) or **upstream** (errors/acknowledgments). A processor receives a frame, does its work, and pushes it along — by default in the direction it came.
+- **Change a running pipeline by pushing frames, not by calling methods.** Pipecat is real-time and ordered: push a frame (e.g. `LLMSetToolsFrame` to swap tools, a context-update frame to add a message) so the change stays in sequence with frames already in flight; reaching into an object directly (e.g. `context.set_tools()`) jumps the queue and causes subtle ordering bugs. Find the right frame via §3.
+- **A worker runs the show.** For the common single-bot case, wrap your pipeline in a `PipelineWorker`, then run it with a `WorkerRunner`: `await runner.add_workers(worker)`, then `await runner.run()`. The runner owns the shared bus, handles SIGINT/SIGTERM, and by default ends once every root worker finishes; a long-lived host (e.g. a FastAPI server adding/removing sessions) passes `auto_end=False`. In a scaffolded app the dev runner drives all of this per session via your `bot(runner_args)` entry point — you don't wire it by hand.
+- **Pipeline order matters.** The canonical **cascade** voice loop is:
+  ```
+  transport.input()
+    → STT
+    → user context aggregator
+    → LLM
+    → TTS
+    → transport.output()
+    → assistant context aggregator
+  ```
+  **Realtime (speech-to-speech)** is the same loop **without STT and TTS** — the S2S service does both internally:
+  ```
+  transport.input()
+    → user context aggregator
+    → LLM (realtime S2S service)
+    → transport.output()
+    → assistant context aggregator
+  ```
+  In **both**, the **assistant aggregator goes after `transport.output()`** so it records what was actually produced. Getting this order wrong is a common, subtle bug.
+- **Context aggregation** accumulates conversation messages for the LLM. User and assistant aggregators are created together (a pair) and bracket the response leg (LLM→TTS in cascade; the S2S service in realtime) as shown above.
+- **The LLM's output is spoken.** TTS reads exactly what the LLM writes — markdown, emojis, and bullet lists come out as noise. The scaffold's `system_instruction` already guards this: *"Your responses will be spoken aloud, so avoid emojis, bullet points, or other formatting that can't be spoken."* When you rewrite the prompt for the use case, **carry that sentence over**. The bot's turns — including the on-connect greeting — are composed by the LLM by default; making it speak a fixed, verbatim line is a separate mechanism (confirm via §3).
+- **Instructions live in two places — don't pour everything into one.** Durable identity and rules (who the bot is, the voice-safe guard above) live in the LLM's *system instruction*. Turn- or task-specific guidance (what to do next, a fact to use now) goes as a **`developer`** message in the context — Pipecat's standard role for "do this" instructions; its adapters translate it for LLMs that don't support the role natively — the scaffold's greeting already works this way. To seed or steer a turn yourself, add to the context and trigger a response; don't rewrite the system instruction mid-conversation. Confirm the exact roles and frames via §3.
+- **Function calling (tools)** — how the bot *does* things, and where most of your app code goes. A tool is a plain async function: its **name, typed signature, and docstring become the schema automatically**, and it reports back through `params.result_callback` — that's what feeds the result into the conversation so the LLM can speak it:
+  ```python
+  async def check_stock(params: FunctionCallParams, item: str):
+      """Check whether an item is in stock.
+
+      Args:
+          item: The item to look up, e.g. "tulips".
+      """
+      await params.result_callback({"in_stock": True})
+  ```
+  List tools on the context — `LLMContext(tools=[check_stock, ...])` — and they register with the LLM service by themselves; there is no separate registration step to write. To share backend handles or per-session state across handlers, pass `app_resources=` to `PipelineWorker` and read `params.app_resources` (don't use globals). An explicit-schema path (`FunctionSchema` + `llm.register_function`) exists for dynamic tool sets — confirm via §3 if you need it.
+- **Ending the conversation from a tool** (the "goodbye" / hang-up feature nearly every phone bot needs) — push `EndWorkerFrame` from the handler, *after* reporting the result:
+  ```python
+  async def end_call(params: FunctionCallParams):
+      """End the call once the user has said goodbye."""
+      await params.result_callback({"success": True})
+      await params.llm.push_frame(EndWorkerFrame())
+  ```
+  Downstream (the default) is correct: queued frames flush, so the bot can finish speaking before the pipeline ends. Don't invent shutdown paths (`sys.exit`, cancelling tasks) and don't use the deprecated `EndTaskFrame` your training data may suggest. For the prompt pattern that gets the bot to say a goodbye *around* the tool call, find a "graceful end" example via `search_examples` (§3). (Under the hood the pipeline ends with an `EndFrame` — graceful, finishes queued work — or a `CancelFrame` — abrupt; `EndWorkerFrame` is how a processor *requests* the graceful one in order, so the bot finishes its turn instead of being cut off. A bot is also one session per connection — it ends on client disconnect or idle timeout.)
+- **A turn has two phases — start and stop — each driven by a strategy.** The defaults the scaffold wires: VAD + transcription to detect the user *starting*; a smart-turn analyzer + transcript to detect them *stopping*. These defaults are tuned — to change turn-taking, swap or configure the strategies via §3 rather than hand-tweaking timings blind (lowering the stop threshold to feel snappier truncates users).
+- **Interruptions** — when the user barges in, an interruption propagates and clears in-flight work. Most apps get this for free from the turn strategy; to trigger one manually (rare), look up the call via §3.
+- **Background work inside a processor/worker** — when you're *inside* a class that derives from the framework's `BaseObject` (a `FrameProcessor`, a custom worker, a service), use `self.create_task(coro, name)` rather than raw `asyncio.create_task` so the task is tracked and cleaned up on shutdown; cancel with `await self.cancel_task(task, timeout)`. This applies only to `BaseObject` subclasses — plain application code that isn't one of these can use `asyncio` directly.
+- **Structured conversations (Pipecat Flows)** — when the conversation has distinct *stages* with different rules (intake → order → payment → confirmation; branching by intent), don't pile every instruction and tool into one giant system prompt. **Pipecat Flows** (a separate package, `pipecat-ai-flows`; docs on the same site) layers a state machine over the pipeline: each node gets its own prompt, tools, and actions, with explicit transitions. Routing heuristic: a single context + tools (above) is right for most bots; reach for Flows when the prompt/tool set must *change per stage* or the process must be enforced, not suggested. Its API churns — confirm everything via §3 before writing Flows code.
+- **Multi-worker (advanced)** — multiple *concurrently running* workers cooperating over a shared **bus**, calling each other via **jobs** / **job groups** and discovering each other through a registry. Reach for this only when one pipeline genuinely isn't enough: live handoff between bots, parallel specialists, a separate UI worker. Stages *within* one conversation are Flows territory (above), not multi-worker. Find working examples via `search_examples` and confirm APIs via §3.
+
+> Need more than the model here? Learn deeper via §3 — `search_docs` the Learn pages (turn detection, context, termination, transports) and the Fundamentals guides (optional features) *before* building them. For framework internals, the framework's own AGENTS.md "Architecture" and "Workers, Bus, and Jobs" sections help — but get *API specifics* from §3, not from prose.
+
+---
+
+## 5. Secrets & environment
+
+- Keep a `.env.example` listing every key the app needs; never commit real keys.
+- Before running anything, check which providers are wired and confirm the user has the corresponding keys. If a key is missing, **stop and ask** — name the provider and the env var.
+
+---
+
+## 6. Verify your work (the eval harness)
+
+A voice app can't be eyeballed like a web page — but you don't need a live call to test it. Pipecat ships a **behavioral eval harness** (`pipecat.evals`): scripted YAML scenarios drive your *running bot* and assert on what it does — deterministic checks (substring, function name/args, latency) plus an optional LLM **judge** for natural-language criteria — exercising the whole pipeline (STT→LLM→TTS, turns, context, tools, interruptions) end to end.
+
+> **Deep reference:** the **Pipecat Evals docs** are the authoritative spec — look them up via your Pipecat MCP (§3): **Overview**, **Writing Scenarios** (the schema + the two modality axes), **Using the Library** (the Python API), **Agent Self-Improvement** (the closed-loop workflow this section describes). For working examples, copy the **scaffolded starters in `server/evals/`** rather than writing YAML from scratch. The eval harness ships in the `pipecat-ai[evals]` extra (the `pipecat eval` command plus the local Kokoro/Moonshine speech models); scaffolding with `--eval` adds it, so run evals from the **bot's own environment**.
+
+**Make your bot eval-able.** Scaffold with `pipecat init . --eval` (headless) — pass it whenever you scaffold a bot you intend to test. The generated bot has the `eval` transport entry, eval dependencies in its env, and **runnable starter scenarios in `server/evals/`**: `starter_text.yaml` (the fast inner loop; cascade only) and `starter_audio.yaml` (the full round trip). They pass against the freshly scaffolded bot, so run them *first* to prove the loop, then edit them to match the bot you're building and copy them to grow the suite. For an **existing** bot, add the transport entry by hand (a one-time change; RTVI is already on by default for `PipelineWorker`, so that's the only edit):
+```python
+from pipecat.evals.transport import EvalTransportParams
+
+transport_params = {
+    "eval": lambda: EvalTransportParams(audio_in_enabled=True, audio_out_enabled=True),
+    # ... your real transports (smallwebrtc, daily, …) stay as-is
+}
+```
+The dev runner wraps this in the eval transport + serializer when you pass `-t eval`; you don't construct them. Two kinds of checks follow: quick smoke checks when you wire it up, then the eval loop you run as you work.
+
+**Smoke checks (when you wire it up).** Two fast "did I break the plumbing" checks before any scenario:
+- **Logs** — the bot logs to stdout (loguru). However you run it, keep the output durable and greppable — e.g. `uv run bot.py -t eval 2>&1 | tee /tmp/pipecat-output.txt` — so when a scenario fails you can grep the file for the traceback instead of re-running. If your harness captures background-process output natively, that works too.
+- **Clean boot** — `uv run bot.py -t eval` boots the bot as a headless eval WebSocket server (default `ws://localhost:7860`). No exceptions + pipeline assembled is your fastest "did I wire it right" signal.
+
+**The eval loop (where you live).** Boot the bot (`uv run bot.py -t eval`), then drive a scenario against it from a second terminal. The eval transport keeps the bot alive between runs, so boot it once and drive scenario after scenario as you iterate — no re-boot per run. Start in **text mode** (the default), the fast inner loop. A minimal scenario:
+```yaml
+name: capital_of_germany
+turns:
+  # Wait for the bot's on-connect greeting before speaking (avoids barging into it).
+  - expect:
+      - event: response
+        eval: "the bot opens the conversation in some way (a greeting, an introduction, an offer to help, or a question to get the user started)"
+
+  - user: "What is the capital of Germany?"
+    expect:
+      - event: response
+        eval: "the response says the capital of Germany is Berlin"
+```
+```bash
+uv run pipecat eval run my_scenario.yaml -v
+```
+Text mode **bypasses STT, VAD, and TTS** (the `user:` turn is sent as text), so assert on what the bot *produced* (`response`, `function_call`), not on `user_*_speaking` events. Prefer the modality-agnostic `response` event — it resolves to the LLM text in text mode and to the bot's transcribed audio in audio mode. Exit code is non-zero if any non-skipped scenario fails. When a run fails in a confusing way, re-run with `-d` to also write `<scenario>.debug.log` — the harness's full logs for the eval STT, TTS, and LLM judge. Route run output to `eval-runs/` with `--logs-dir eval-runs` (and `--record-dir eval-runs` for `-a` recordings); `pipecat eval suite` writes runs to a timestamped `eval-runs/<timestamp>/`.
+
+**One bot serves many runs.** Because the bot stays up between runs, its context carries over — give a scenario a top-level `context:` (a list of LLM messages) to start that run from a known context, or boot fresh / use `pipecat eval suite` (a fresh bot per scenario from a manifest) when you want each run fully isolated. Its `on_client_disconnected` handler (which usually cancels the pipeline) also won't fire during a normal eval; to exercise that path — cleanup, or a goodbye on hang-up — pass `--trigger-disconnect` to `pipecat eval run`, or set `trigger_disconnect: true` on a single scenario. If the handler cancels the pipeline the bot exits, so treat that as a terminal run.
+
+**Escalate to audio mode** for the full round trip. Set `user: {modality: audio, speech: {service: kokoro, voice: af_heart}}` and the harness synthesizes the user's speech, so the bot's **real VAD + STT** run; set `judge: {modality: audio}` (with a `transcription:` block) so the bot **speaks** and the harness transcribes that audio into the `response` event. Kokoro (user TTS) and Moonshine (bot transcription) run **locally with no API key** — audio mode is slower but free. Add `-a` to save the conversation to `<record-dir>/<scenario>.wav` for a human to listen back and confirm it sounds right.
+
+**Which mode — iterate in text, confirm in audio.** Default to **text** for the inner loop and anything about the bot's *decisions* (LLM content, system-prompt adherence, function calls, multi-turn context, barge-in) — it's fast and cheap, so run it constantly. Escalate a scenario to **audio** when text mode would *lie*, i.e. when the thing under test is the audio path itself:
+
+| Use **audio** when… | Why text mode is insufficient |
+|---|---|
+| correctness depends on how real speech transcribes (numbers, names, accents, homophones) | text skips STT — it never sees a transcript |
+| turn-taking / end-of-turn / VAD timing matters | text skips VAD |
+| you assert `user_started_speaking` / `user_stopped_speaking` / `tts_response` | these events **only fire in audio mode** (`user_transcription` fires in both modes — STT in audio, DTMF aggregator in text) |
+| TTS intelligibility / pronunciation matters | needs `judge: {modality: audio}` so you judge the transcription of real speech (`response`) |
+| final pre-ship / CI confidence pass over the real round trip | text never exercises the real STT/VAD/TTS round trip |
+
+Heuristic: **text tests the brain; audio tests the ears and mouth.** The **judge is orthogonal to the mode** — `eval:` natural-language criteria work in either (a local Ollama with `gemma4:12b` by default, or `judge: {service: openai, model: gpt-4.1}`).
+
+**Realtime (speech-to-speech) bots are audio-mode only.** An S2S model has no separate text LLM step to assert on, so text mode doesn't apply — eval it the same way a person would talk to it: `user: {modality: audio}` to synthesize the user's voice in, `judge: {modality: audio}` to transcribe its spoken output for the judge. Same Kokoro-in / Moonshine-out path as above, just **required** rather than an escalation; scenarios, the judge, and assertions are otherwise identical to a cascade bot.
+
+> **Gotchas:** Only `eval:` natural-language criteria need a judge — deterministic checks (`text_contains`, `function_call`) need none. For the judge, use a free local model (Ollama) if one is already available; otherwise ask the user whether to pull it (`ollama pull gemma4:12b`, ~7.6 GB) or reuse the bot's provider key. Audio-mode scenarios need `audio_in_enabled=True` on the eval transport (above).
+
+---
+
+## 7. Deploying (optional — Pipecat Cloud)
+
+[Pipecat Cloud](https://www.daily.co/products/pipecat-cloud/) is a **hosted** option — deploying there is optional (run locally or host elsewhere instead). It's a scaffold-time choice: `--deploy-to-cloud` (default on, §1) generates the `Dockerfile` + `pcc-deploy.toml`; with `--no-deploy-to-cloud` you'd add those by hand later. **Before deploying, confirm the user wants Pipecat Cloud and has an account** — you can't create one for them.
+
+> `pipecat cloud` is an **optional plugin**, not bundled with `pipecat-ai[cli]`. Install it alongside: `uv tool install "pipecat-ai[cli]" --with pipecatcloud`. (Without it, `pipecat cloud` lists in `--help` but prints how to enable it when run.)
+
+Auth is a one-time **user** action (a browser login — you can't do it for them); after it, deploy runs non-interactively:
+
+```bash
+# 1. one-time, by the user (browser login)
+pipecat cloud auth login
+
+# 2. Secret set — REQUIRED: a deployed bot has none of your local .env, so without it it
+#    starts but every service call fails on missing keys. Name must match `secret_set` in pcc-deploy.toml.
+pipecat cloud secrets set <secret_set-name> --file .env --skip
+
+# 3. builds from the Dockerfile + pcc-deploy.toml; --yes skips confirms (agents/CI)
+pipecat cloud deploy --yes
+```
+
+Re-set the secrets whenever keys change. Tail a live bot with `pipecat cloud agent logs <agent-name>`.
+
+**Krisp noise cancellation** (`--enable-krisp`, requires cloud) is Cloud-provided, and **the scaffold already wires it correctly — keep that block, don't re-wire it**:
+- The generated `if os.environ.get("ENV") != "local"` guard, plus the dev runner forcing `ENV=local` on every local run (including `-t eval`), means the bot boots locally with no Krisp model or license and turns Krisp on only once deployed to Pipecat Cloud. Don't add your own guard.
+- Deploying to Pipecat Cloud → the scaffold default is already right; don't ask the user how to wire Krisp.
+- Krisp with **no** cloud deploy is the only case to raise: the user self-hosts the SDK + model (`KRISP_VIVA_FILTER_MODEL_PATH`, `KRISP_VIVA_API_KEY`).
+
+<!-- Generated by `pipecat init` (pipecat-ai 1.8.1). Run `pipecat init --overwrite-guide` to refresh. -->

--- a/phonellm/CLAUDE.md
+++ b/phonellm/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/phonellm/README.md
+++ b/phonellm/README.md
@@ -1,11 +1,11 @@
-# PhoneLLM Example
+# Pipecat PhoneLLM Example
 
-[PhoneLLM](https://huggingface.co/pipecat-ai/phonellm-alpha-1) is an open-weights 30B language model from the Pipecat team, fine-tuned for voice agents that handle phone calls — faster and cheaper than larger general-purpose models.
+[Pipecat PhoneLLM](https://huggingface.co/pipecat-ai/phonellm-alpha-1) is an open-weights 30B language model from the Pipecat team, fine-tuned for voice agents that handle phone calls. It's accurate at tool calling, fast, and low cost — making it ideal for phone use cases such as customer service agents.
 
 > [!TIP]
 > **Quickstart:** using [Claude Code](https://claude.com/claude-code)? Run `/setup` in this repo — a committed skill (`.claude/skills/setup/`) that steps through everything below, health-checking along the way and asking for input only where needed. The rest of this README is the manual path.
 
-This repo is a [Pipecat](https://github.com/pipecat-ai/pipecat) voice agent that runs PhoneLLM on [Modal](https://modal.com), with Deepgram Flux for speech-to-text and Deepgram Aura for text-to-speech.
+This repo is a [Pipecat](https://github.com/pipecat-ai/pipecat) voice agent that runs Pipecat PhoneLLM on [Modal](https://modal.com), with Deepgram Flux for speech-to-text and Deepgram Aura for text-to-speech.
 
 ```
 Deepgram Flux (STT) → Pipecat PhoneLLM Alpha 1 on Modal (LLM) → Deepgram Aura (TTS)

--- a/phonellm/README.md
+++ b/phonellm/README.md
@@ -1,0 +1,170 @@
+# PhoneLLM Example
+
+[PhoneLLM](https://huggingface.co/pipecat-ai/phonellm-alpha-1) is an open-weights 30B language model from the Pipecat team, fine-tuned for voice agents that handle phone calls — faster and cheaper than larger general-purpose models.
+
+> [!TIP]
+> **Quickstart:** using [Claude Code](https://claude.com/claude-code)? Run `/setup` in this repo — a committed skill (`.claude/skills/setup/`) that steps through everything below, health-checking along the way and asking for input only where needed. The rest of this README is the manual path.
+
+This repo is a [Pipecat](https://github.com/pipecat-ai/pipecat) voice agent that runs PhoneLLM on [Modal](https://modal.com), with Deepgram Flux for speech-to-text and Deepgram Aura for text-to-speech.
+
+```
+Deepgram Flux (STT) → Pipecat PhoneLLM Alpha 1 on Modal (LLM) → Deepgram Aura (TTS)
+```
+
+## Install the CLIs
+
+```bash
+uv tool install "pipecat-ai[cli]"
+uv tool install modal
+```
+
+## Provision PhoneLLM on Modal
+
+### 1. Log in
+
+```bash
+modal setup
+```
+
+This opens your browser to authenticate and writes your API credentials to a local Modal profile.
+
+### 2. Create the endpoint
+
+```bash
+modal endpoint create --model pipecat-ai/phonellm-alpha-1
+```
+
+Modal provisions an [Auto Endpoint](https://modal.com/docs/guide/endpoints) — a production-ready, OpenAI-compatible inference server for PhoneLLM. **Note the endpoint URL it prints; you'll need it below.** This process can take ~20 minutes.
+
+> **Note:** The CLI can't retrieve the endpoint URL after the fact — `modal endpoint list` shows status but not the URL. If you lose it, find it on the endpoint's page in the [Modal dashboard](https://modal.com/) (`modal dashboard` opens it).
+
+### 3. Check that it's running
+
+List your endpoints and their status (`provisioning` → `live`):
+
+```bash
+modal endpoint list
+```
+
+Once it's running, you can send a quick authenticated request using your local Modal credentials (no token required):
+
+```bash
+modal curl <endpoint-url>/v1/models
+```
+
+A JSON response listing `pipecat-ai/phonellm-alpha-1` means the endpoint is healthy.
+
+> **Note:** Endpoints scale to zero when idle. The first request after creation (or after a quiet period) returns 503 while the model spins up — this can take several minutes for a 30B model, and the container logs (`modal app logs`) may go quiet during kernel compilation. Keep retrying.
+
+### 4. Create a proxy token
+
+The bot authenticates with a workspace proxy token rather than your local credentials:
+
+```bash
+modal workspace proxy-tokens create
+```
+
+This prints a token ID (`wk-...`) and secret (`ws-...`). Save the secret now — it can't be retrieved later. Combined as `<token-id>.<token-secret>`, they form the API key the bot sends as a Bearer token.
+
+On workspaces with RBAC enabled, new tokens start with no environment access, and the endpoint rejects them with `401 "Webhook token not found"`. Allow the token into the environment the endpoint lives in (`main` unless you created it elsewhere):
+
+```bash
+modal workspace proxy-tokens allow <token-id> main
+```
+
+### 5. Verify end to end (optional)
+
+Test the exact request path the bot will use — proxy-token auth against the chat completions API:
+
+```bash
+curl "<endpoint-url>/v1/chat/completions" \
+  -H "Authorization: Bearer <token-id>.<token-secret>" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "pipecat-ai/phonellm-alpha-1", "messages": [{"role": "user", "content": "Hello!"}]}'
+```
+
+## Configure the bot
+
+```bash
+cd server
+cp .env.example .env
+```
+
+In `.env`, set:
+
+- `MODAL_ENDPOINT_URL` — the endpoint URL from `modal endpoint create` (or the Modal dashboard)
+- `MODAL_API_KEY` — the proxy token, combined as `<token-id>.<token-secret>` (`wk-....ws-...`)
+- `DEEPGRAM_API_KEY` — your [Deepgram](https://console.deepgram.com) API key
+
+## Run the bot
+
+Install dependencies and start the bot:
+
+```bash
+uv sync
+uv run bot.py
+```
+
+Open http://localhost:7860 in your browser and talk to it.
+
+### Test it headless
+
+The repo ships a behavioral smoke test that drives the whole pipeline — greeting, a factual answer, and multi-turn context — against the live endpoint, no microphone needed. Boot the bot with the eval transport, then run the scenario from a second terminal (both from `server/`):
+
+```bash
+uv run bot.py -t eval
+uv run pipecat eval run evals/phonellm_smoke.yaml -v
+```
+
+The checks are deterministic, so no judge LLM is required.
+
+## Deploying to Pipecat Cloud
+
+The quickest path is a [cloud build](https://docs.pipecat.ai/pipecat-cloud/guides/cloud-builds): `pipecat cloud deploy` uploads your source and builds the image on Pipecat Cloud from the committed `server/Dockerfile` — no local Docker, no container registry. The deploy config is already in `server/pcc-deploy.toml`. You'll need a [Pipecat Cloud account](https://pipecat.daily.co) and the cloud plugin:
+
+```bash
+uv tool install "pipecat-ai[cli]" --with pipecatcloud
+```
+
+### 1. Log in (one time)
+
+```bash
+pipecat cloud auth login
+```
+
+### 2. Upload your secrets
+
+A deployed bot doesn't have your local `.env`, so push it as a secret set (the name matches `secret_set` in `pcc-deploy.toml`). From `server/`:
+
+```bash
+pipecat cloud secrets set phonellm-example-secrets --file .env --skip
+```
+
+Re-run this whenever a key changes.
+
+### 3. Deploy
+
+From `server/`:
+
+```bash
+pipecat cloud deploy
+```
+
+The CLI tars up the project (excluding `.env`, `.venv`, etc.), builds the image in the cloud, and deploys it. Builds are content-hashed, so redeploying unchanged code reuses the cached build and is nearly instant.
+
+### 4. Check on it
+
+```bash
+pipecat cloud agent status phonellm-example
+pipecat cloud agent logs phonellm-example
+```
+
+> **Note:** The `[krisp_viva]` block in `pcc-deploy.toml` enables Krisp noise cancellation on Cloud; the bot skips it automatically when running locally.
+
+## Cleaning up
+
+To permanently stop the endpoint and its containers (the `ep-...` ID comes from `modal endpoint list`):
+
+```bash
+modal endpoint stop <endpoint-id>
+```

--- a/phonellm/server/.env.example
+++ b/phonellm/server/.env.example
@@ -1,0 +1,20 @@
+# phonellm-example - Environment Variables
+# Copy this file to .env and fill in your keys
+
+# PhoneLLM on Modal
+# Endpoint URL printed by `modal endpoint create` (or from the Modal dashboard —
+# the CLI can't retrieve it after creation)
+MODAL_ENDPOINT_URL=
+# Proxy token from `modal workspace proxy-tokens create`,
+# combined as <token-id>.<token-secret> (wk-....ws-...)
+MODAL_API_KEY=
+
+# Deepgram (Flux STT + TTS)
+DEEPGRAM_API_KEY=
+# Optional: Aura voice for TTS (default: aura-2-helena-en)
+# DEEPGRAM_VOICE_ID=
+
+# Daily (Transport) — only needed when running with `-t daily`
+DAILY_API_KEY=
+# Optional: leave empty to create a new room
+# DAILY_ROOM_URL=

--- a/phonellm/server/Dockerfile
+++ b/phonellm/server/Dockerfile
@@ -1,0 +1,19 @@
+FROM dailyco/pipecat-base:latest
+
+# Enable bytecode compilation
+ENV UV_COMPILE_BYTECODE=1
+
+# Copy from the cache instead of linking since it's a mounted volume
+ENV UV_LINK_MODE=copy
+
+# Uncomment if you wish to print a summary of the features available in the base image
+# ENV PCC_LOG_FEATURES_SUMMARY=true
+
+# Install the project's dependencies using the lockfile and settings
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project --no-dev
+
+# Copy the application code
+COPY ./bot.py bot.py

--- a/phonellm/server/bot.py
+++ b/phonellm/server/bot.py
@@ -1,0 +1,183 @@
+#
+# Copyright (c) 2024–2025, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""phonellm-example - Pipecat Voice Agent
+
+This bot uses a cascade pipeline: Speech-to-Text → LLM → Text-to-Speech
+
+Required AI services:
+- Deepgram Flux (Speech-to-Text)
+- PhoneLLM on Modal (LLM)
+- Deepgram (Text-to-Speech)
+
+Run the bot using::
+
+    uv run bot.py
+"""
+
+import os
+
+from dotenv import load_dotenv
+from loguru import logger
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.evals.transport import EvalTransportParams
+from pipecat.frames.frames import LLMRunFrame
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import create_transport
+from pipecat.services.deepgram.flux.stt import DeepgramFluxSTTService
+from pipecat.services.deepgram.tts import DeepgramTTSService
+from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.daily.transport import DailyParams
+from pipecat.workers.runner import WorkerRunner
+
+load_dotenv(override=True)
+
+
+def require_env(name: str) -> str:
+    """Return the value of a required environment variable or raise."""
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments) -> None:
+    """Run the voice bot for this session.
+
+    Args:
+        transport: The transport for this session, built by ``create_transport``
+            (or by hand for the dial-out/SIP production flows).
+        runner_args: Runner session arguments. Carries the request ``body``
+            (e.g. dial-out settings, SIP call details) and ``session_id``; the
+            standard web/telephony pipelines don't need it.
+    """
+    logger.info("Starting bot")
+
+    # Speech-to-Text service
+    stt = DeepgramFluxSTTService(api_key=require_env("DEEPGRAM_API_KEY"))
+
+    # Text-to-Speech service
+    tts = DeepgramTTSService(
+        api_key=require_env("DEEPGRAM_API_KEY"),
+        settings=DeepgramTTSService.Settings(
+            voice=os.getenv("DEEPGRAM_VOICE_ID", "aura-2-helena-en"),
+        ),
+    )
+
+    # LLM service: PhoneLLM served by a Modal endpoint (OpenAI-compatible API).
+    # MODAL_ENDPOINT_URL is the URL printed by `modal endpoint create` / `modal endpoint list`;
+    # MODAL_API_KEY is a proxy token, combined as <token-id>.<token-secret>.
+    llm = OpenAILLMService(
+        api_key=require_env("MODAL_API_KEY"),
+        base_url=f"{require_env('MODAL_ENDPOINT_URL').rstrip('/')}/v1",
+        settings=OpenAILLMService.Settings(
+            model=os.getenv("PHONELLM_MODEL", "pipecat-ai/phonellm-alpha-1"),
+            # PhoneLLM is trained for temperature 0
+            temperature=0,
+            system_instruction="You are a helpful assistant in a voice conversation. You are powered by PhoneLLM. Respond to what the user said in a creative, helpful, and brief way.",
+        ),
+    )
+
+    context = LLMContext()
+    user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+        context,
+        user_params=LLMUserAggregatorParams(
+            # Flux detects turns server-side; the VAD is only used for STT metrics.
+            vad_analyzer=SileroVADAnalyzer(),
+        ),
+    )
+
+    # Pipeline - assembled from reusable components
+    pipeline = Pipeline(
+        [
+            transport.input(),
+            stt,
+            user_aggregator,
+            llm,
+            tts,
+            transport.output(),
+            assistant_aggregator,
+        ]
+    )
+
+    worker = PipelineWorker(
+        pipeline,
+        params=PipelineParams(
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+        observers=[],
+    )
+
+    @worker.rtvi.event_handler("on_client_ready")
+    async def on_client_ready(rtvi):
+        # Kick off the conversation
+        context.add_message(
+            {"role": "developer", "content": "Start by concisely introducing yourself."}
+        )
+        await worker.queue_frames([LLMRunFrame()])
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        logger.info("Client connected")
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info("Client disconnected")
+        await worker.cancel()
+
+    runner = WorkerRunner(handle_sigint=False)
+
+    await runner.add_workers(worker)
+    await runner.run()
+
+
+async def bot(runner_args: RunnerArguments):
+    """Main bot entry point."""
+
+    # Krisp is available when deployed to Pipecat Cloud
+    if os.environ.get("ENV") != "local":
+        from pipecat.audio.filters.krisp_viva_filter import KrispVivaFilter
+
+        krisp_filter = KrispVivaFilter()
+    else:
+        krisp_filter = None
+
+    transport_params = {
+        "daily": lambda: DailyParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+            audio_in_filter=krisp_filter,
+        ),
+        "webrtc": lambda: TransportParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+            audio_in_filter=krisp_filter,
+        ),
+        # Behavioral evals: run with `-t eval` to drive this bot via `pipecat eval`.
+        "eval": lambda: EvalTransportParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+        ),
+    }
+
+    transport = await create_transport(runner_args, transport_params)
+
+    await run_bot(transport, runner_args)
+
+
+if __name__ == "__main__":
+    from pipecat.runner.run import main
+
+    main()

--- a/phonellm/server/evals/phonellm_smoke.yaml
+++ b/phonellm/server/evals/phonellm_smoke.yaml
@@ -1,0 +1,28 @@
+name: phonellm_smoke
+
+# Deterministic smoke test for the PhoneLLM pipeline — text mode, no judge LLM needed.
+#
+# Text mode bypasses VAD, STT, and TTS: each `user:` turn is sent as text and the
+# assertions run against the LLM's text output, so this exercises the bot's
+# pipeline and the PhoneLLM endpoint on Modal end to end.
+#
+# Run it (two terminals, both in server/):
+#
+#   uv run bot.py -t eval                                   # 1: the bot, headless
+#   uv run pipecat eval run evals/phonellm_smoke.yaml -v    # 2: this scenario
+
+turns:
+  # The bot speaks first on connect; wait for the greeting so we don't barge in.
+  - expect:
+      - event: response
+
+  - user: "What is the capital of Germany? Answer in one short sentence."
+    expect:
+      - event: response
+        text_contains: "Berlin"
+
+  # Multi-turn context: this only passes if the previous turn carried over.
+  - user: "And what about France?"
+    expect:
+      - event: response
+        text_contains: "Paris"

--- a/phonellm/server/pcc-deploy.toml
+++ b/phonellm/server/pcc-deploy.toml
@@ -1,0 +1,8 @@
+agent_name = "phonellm-example"
+secret_set = "phonellm-example-secrets"
+agent_profile = "agent-1x"
+[krisp_viva]
+	audio_filter = "tel"
+
+[scaling]
+	min_agents = 1

--- a/phonellm/server/pyproject.toml
+++ b/phonellm/server/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "phonellm-example"
+version = "0.1.0"
+description = "PhoneLLM voice bot built with Pipecat"
+requires-python = ">=3.11"
+dependencies = [
+    "pipecat-ai[daily,deepgram,evals,openai,runner,silero,webrtc]>=1.8.1",
+    "pipecatcloud",
+]
+
+[dependency-groups]
+dev = ["pyright>=1.1.404,<2", "ruff>=0.12.11,<1"]
+
+[tool.ruff]
+line-length = 100
+[tool.ruff.lint]
+select = ["I", "UP"]


### PR DESCRIPTION
Adds `phonellm/`, an example voice agent running [PhoneLLM](https://huggingface.co/pipecat-ai/phonellm-alpha-1) (the Pipecat team's open-weights 30B model for phone-call voice agents) on Modal, with Deepgram Flux STT and Deepgram Aura TTS.

Includes:
- `server/bot.py` — Pipecat cascade pipeline against the Modal-hosted PhoneLLM endpoint
- Headless behavioral smoke test (`server/evals/phonellm_smoke.yaml`)
- Pipecat Cloud deploy config (`Dockerfile`, `pcc-deploy.toml`)
- README covering Modal provisioning, local run, and cloud deploy, plus a committed `/setup` Claude Code skill that automates it